### PR TITLE
feat: Phase 4.2 - スタッフリストのFirestore統合

### DIFF
--- a/.kiro/specs/auth-data-persistence/tasks.md
+++ b/.kiro/specs/auth-data-persistence/tasks.md
@@ -127,10 +127,11 @@ Phase 1-3のすべての機能が本番環境にデプロイされ、動作確�
   - **実装**: `src/services/staffService.ts` - StaffService（CRUD操作、リアルタイムリスナー）
   - **テスト**: `src/services/__tests__/staffService.test.ts` - TDDアプローチで実装
 
-- [ ] 4.2 既存スタッフリストコンポーネントのFirestore統合
-  - リアルタイムリスナーによるスタッフデータの自動更新
-  - スタッフリストUIとFirestoreデータの同期
-  - スタッフ追加・編集・削除UIのFirestore連携
+- [x] 4.2 既存スタッフリストコンポーネントのFirestore統合
+  - **実装**: `App.tsx` - StaffService統合（リアルタイムリスナー、CRUD操作）
+  - リアルタイムリスナーによるスタッフデータの自動更新（subscribeToStaffList）
+  - スタッフ追加・編集・削除UIのFirestore連携（createStaff, updateStaff, deleteStaff）
+  - ローディング状態の表示
   - _Requirements: 3.5, 3.6_
 
 - [ ] 4.3 スタッフ情報の読み込みとエラーハンドリング


### PR DESCRIPTION
## 概要

Phase 4.2: 既存スタッフリストコンポーネントのFirestore統合

App.tsxでStaffServiceを統合し、スタッフ情報をFirestoreでリアルタイムに管理するように実装しました。

## 実装内容

### リアルタイムデータ購読

- **useEffect** で `StaffService.subscribeToStaffList` をセットアップ
- `selectedFacilityId` が変更されると自動的に再購読
- Firestore の変更をリアルタイムで UI に反映
- エラーハンドリング: try-catch でサブスクリプション設定エラーをキャッチ

### CRUD操作の統合

**作成 (handleAddNewStaff)**:
- `StaffService.createStaff` を呼び出し
- 成功時に新規スタッフを自動展開

**更新 (handleStaffChange)**:
- 楽観的 UI アップデートで即座に反映
- `StaffService.updateStaff` を呼び出し
- 失敗時に楽観的アップデートをrevert

**削除 (executeDeleteStaff)**:
- `StaffService.deleteStaff` を呼び出し
- 成功時に関連データ（休暇希望、業務日誌）もクリーンアップ

### UI改善

- ローディングインジケーター追加（スタッフ情報読み込み中）
- エラーメッセージ表示（CRUD操作失敗時、購読設定失敗時）
- initialStaff ハードコードデータを削除

### 認証統合

- `useAuth` フックで `selectedFacilityId` を取得
- 施設が選択されていない場合は空リスト表示

## 技術的特徴

- **リアルタイムリスナー**: Firestoreの変更を自動で同期
- **楽観的UIアップデート**: レスポンシブなUX（失敗時はrevert）
- **Result型パターン**: 型安全なエラーハンドリング
- **エラーリカバリー**: 購読エラー時も適切にフォールバック

## CodeRabbitフィードバック対応

1. ✅ 楽観的UIアップデートの失敗時revert実装
2. ✅ サブスクリプション設定のエラーハンドリング追加

## テスト

- Firebase Emulatorでの手動テスト推奨
- 統合テストはPhase 4.3で追加予定

## 関連タスク

- tasks.md の 4.2 を完了としてマーク

## 次のステップ

Phase 4.3: スタッフ情報の読み込みとエラーハンドリングの強化

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time staff data synchronization from the database
  * Create new staff members asynchronously
  * Delete staff members with automatic related data cleanup

* **Improvements**
  * Added loading indicators during staff data retrieval
  * Enhanced error handling for staff operations with user feedback
  * Optimistic UI updates for staff edits with automatic reversion on errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->