### PR TITLE
Phase 6.2 - シフト確定とバージョン履歴作成機能

### DIFF
--- a/.kiro/specs/auth-data-persistence/tasks.md
+++ b/.kiro/specs/auth-data-persistence/tasks.md
@@ -195,12 +195,16 @@ Phase 1-3のすべての機能が本番環境にデプロイされ、動作確�
   - **実装**: `scheduleService.ts` - updateScheduleメソッド追加
   - currentScheduleIdのトラッキングでFirestore更新をサポート
 
-- [ ] 6.2 シフト確定とバージョン履歴作成機能の実装
+- [x] 6.2 シフト確定とバージョン履歴作成機能の実装
   - 「確定」ボタンによるstatus変更（draft → confirmed）
   - 現在のシフトデータをversionsサブコレクションに保存
   - バージョン番号のインクリメントとタイムスタンプ記録
   - トランザクションによる原子性の保証
   - _Requirements: 4.6, シフトのバージョン管理（design.md）_
+  - **実装**: `scheduleService.ts` - confirmScheduleメソッド追加（runTransactionで原子性保証）
+  - **実装**: `App.tsx` - currentScheduleStatus state追加、handleConfirmSchedule実装、確定ボタン追加
+  - **実装**: バージョン履歴はversionsサブコレクション（/facilities/{facilityId}/schedules/{scheduleId}/versions/{versionNumber}）に保存
+  - 下書き状態（draft）のみ確定可能、確定後はボタン無効化
 
 - [ ] 6.3 バージョン履歴の表示と過去バージョンへの復元機能
   - シフトの全バージョン履歴を時系列で表示


### PR DESCRIPTION
## 概要

Phase 6.2 「シフト確定とバージョン履歴作成機能」を実装しました。

## 実装内容

### 1. ScheduleService.confirmSchedule メソッド (src/services/scheduleService.ts:309-461)
- トランザクション（runTransaction）でバージョン履歴作成とステータス更新を原子的に実行
- status='draft' のスケジュールのみ確定可能
- 現在のシフトデータをversionsサブコレクションに保存
- バージョン番号を自動インクリメント
- エラーハンドリング：NOT_FOUND, CONFLICT, VALIDATION_ERROR, PERMISSION_DENIED

### 2. App.tsx - ステータス管理と確定ハンドラー
- currentScheduleStatus state追加（行48）
- リアルタイムリスナーでステータスを取得・保存（行147, 152）
- handleConfirmSchedule実装（行476-516）
  - バリデーション
  - draftステータスチェック
  - ScheduleService.confirmSchedule呼び出し
  - トースト通知
  - LocalStorage下書き削除

### 3. UI - 確定ボタン追加（App.tsx:691-700）
- 緑色の「確定」ボタン
- draftステータスのみ有効化
- チェックマークアイコン

### 4. バージョン履歴データ構造
- Firestoreパス: `/facilities/{facilityId}/schedules/{scheduleId}/versions/{versionNumber}`
- 各バージョンに以下を記録：
  - versionNumber
  - targetMonth
  - staffSchedules（シフトデータ）
  - createdAt
  - createdBy
  - changeDescription
  - previousVersion

## 変更ファイル
- `src/services/scheduleService.ts` - confirmScheduleメソッド追加
- `App.tsx` - ステータス管理、確定ハンドラー、確定ボタン
- `.kiro/specs/auth-data-persistence/tasks.md` - Phase 6.2完了マーク

## テスト確認項目
- [ ] 下書き状態のシフトを確定できること
- [ ] 確定ボタンはdraftステータスのみ有効であること
- [ ] 確定後にversionsサブコレクションにバージョンが保存されること
- [ ] 確定後にステータスがconfirmedになること
- [ ] 確定後にバージョン番号がインクリメントされること
- [ ] トースト通知が表示されること
- [ ] LocalStorageの下書きが削除されること
- [ ] 確定済みシフトは再確定できないこと

## 注意事項
- CodeRabbitローカルレビューがサービスのハングにより実行できませんでした
- 手動コードレビューを実施し、設計書通りの実装を確認済み
- GitHub Actions CI/CDで追加チェックを実施

## 関連タスク
関連タスク: `.kiro/specs/auth-data-persistence/tasks.md` Phase 6.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schedule confirmation workflow with a new confirmation button to finalize draft schedules
  * Introduced automatic versioning system that preserves confirmed schedule data for audit trail
  * Implemented draft-only constraint: schedules can only be confirmed when in draft status

* **UI Updates**
  * Save Draft button is now disabled for non-draft schedules
  * Confirm button is enabled only for active draft schedules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->