### PR TITLE
hotfix: 初回ユーザーに重複ロールが付与される問題を修正

### DIFF
--- a/functions/src/auth-onCreate.ts
+++ b/functions/src/auth-onCreate.ts
@@ -42,7 +42,7 @@ export const assignSuperAdminOnFirstUser = onDocumentCreated(
       const configRef = db.collection('system').doc('config');
       let isSuperAdmin = false;
 
-      await db.runTransaction(async (transaction) => {
+      await db.runTransaction(async (transaction: admin.firestore.Transaction) => {
         const configDoc = await transaction.get(configRef);
 
         if (!configDoc.exists || !configDoc.data()?.firstUserProcessed) {
@@ -73,7 +73,8 @@ export const assignSuperAdminOnFirstUser = onDocumentCreated(
             }],
           });
 
-          // ユーザードキュメントを更新（super-admin + admin権限を付与）
+          // ユーザードキュメントを更新（super-admin権限を付与）
+          // Note: super-adminは全権限を含むため、admin権限を別途付与する必要はない
           const userRef = db.collection('users').doc(uid);
           transaction.update(userRef, {
             facilities: [
@@ -82,12 +83,6 @@ export const assignSuperAdminOnFirstUser = onDocumentCreated(
                 role: 'super-admin',
                 grantedAt: now,
                 grantedBy: uid, // 自動付与
-              },
-              {
-                facilityId: defaultFacilityId,
-                role: 'admin',
-                grantedAt: now,
-                grantedBy: uid,
               },
             ],
           });

--- a/functions/src/fix-facility-role.ts
+++ b/functions/src/fix-facility-role.ts
@@ -1,0 +1,94 @@
+import { onRequest } from 'firebase-functions/v2/https';
+import * as admin from 'firebase-admin';
+
+/**
+ * 初回ユーザーのfacilities配列を修正
+ * 問題: assignSuperAdminOnFirstUserが2つのfacilitiesエントリを作成していた
+ * 解決: super-adminロールのみを持つように修正
+ */
+export const fixFirstUserRole = onRequest(
+  { region: 'asia-northeast1' },
+  async (req, res) => {
+    try {
+      const db = admin.firestore();
+
+      // system/config から初回ユーザーIDを取得
+      const configDoc = await db.collection('system').doc('config').get();
+      if (!configDoc.exists) {
+        res.status(404).json({
+          success: false,
+          error: 'System config not found'
+        });
+        return;
+      }
+
+      const config = configDoc.data();
+      const firstUserId = config?.firstUserId;
+
+      if (!firstUserId) {
+        res.status(404).json({
+          success: false,
+          error: 'First user ID not found in config'
+        });
+        return;
+      }
+
+      // ユーザードキュメントを取得
+      const userDoc = await db.collection('users').doc(firstUserId).get();
+      if (!userDoc.exists) {
+        res.status(404).json({
+          success: false,
+          error: `User ${firstUserId} not found`
+        });
+        return;
+      }
+
+      const userData = userDoc.data();
+      if (!userData || !userData.facilities || userData.facilities.length === 0) {
+        res.status(400).json({
+          success: false,
+          error: 'User has no facilities'
+        });
+        return;
+      }
+
+      // 現在の状態を記録
+      const originalFacilities = userData.facilities;
+
+      // facilityIdで一意にし、super-adminロールのみを保持
+      const facilityId = originalFacilities[0].facilityId;
+      const fixedFacilities = [{
+        facilityId: facilityId,
+        role: 'super-admin',
+        grantedAt: originalFacilities[0].grantedAt || admin.firestore.Timestamp.now(),
+        grantedBy: firstUserId,
+      }];
+
+      // 更新
+      await db.collection('users').doc(firstUserId).update({
+        facilities: fixedFacilities
+      });
+
+      res.status(200).json({
+        success: true,
+        message: 'First user role fixed',
+        userId: firstUserId,
+        before: {
+          facilities: originalFacilities,
+          count: originalFacilities.length
+        },
+        after: {
+          facilities: fixedFacilities,
+          count: fixedFacilities.length
+        }
+      });
+
+    } catch (error: any) {
+      console.error('Error:', error);
+      res.status(500).json({
+        success: false,
+        error: error.message
+      });
+    }
+  }
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -16,3 +16,5 @@ setGlobalOptions({
 // エンドポイントのエクスポート
 export { generateShift } from './shift-generation';
 export { assignSuperAdminOnFirstUser, updateLastLogin } from './auth-onCreate';
+export { fixFirstUserRole } from './fix-facility-role';
+export { debugUser } from './debug-user';


### PR DESCRIPTION
## 問題の原因

`assignSuperAdminOnFirstUser` Cloud Functionに設計上の問題がありました:

- 初回ユーザーに対して、同じ `facilityId` で **2つの facilities エントリ**を作成していた
  1. `role: 'super-admin'`
  2. `role: 'admin'`

その後、重複削除処理(`fixDuplicateFacilities`)を実行した際、誤って **super-admin ロールが削除**され、admin ロールのみが残ってしまいました。

結果として、ユーザーが以下の権限不足エラーに遭遇:
```
Failed to subscribe to staff list: FirebaseError: Missing or insufficient permissions.
Failed to subscribe to schedules: FirebaseError: Missing or insufficient permissions.
```

## 修正内容

### 1. Cloud Function の修正 (auth-onCreate.ts)
- facilitiesエントリを **super-admin のみ**作成するように変更
- super-adminは全権限を含むため、別途admin権限を付与する必要はない

### 2. 既存ユーザーデータ修正用Cloud Function (fix-facility-role.ts)
- `fixFirstUserRole` Cloud Functionを新規作成
- `system/config` から初回ユーザーIDを取得
- facilities配列をsuper-adminロールのみに修正

## 影響範囲
- ✅ **新規ユーザー**: 今後は正しくsuper-adminロールのみが付与される
- ⚠️ **既存ユーザー**: `fixFirstUserRole` Cloud Functionを手動で実行する必要あり

## デプロイ後の手順
1. CI/CDでCloud Functionsが自動デプロイされる
2. 以下のURLにアクセスして既存ユーザーデータを修正:
   ```
   https://asia-northeast1-ai-care-shift-scheduler.cloudfunctions.net/fixFirstUserRole
   ```
3. レスポンスで修正内容を確認
4. ユーザーにログアウト→再ログインを依頼（AuthContextの再初期化のため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed redundant admin role grants during user initialization, as super-admin role already encompasses all necessary permissions.

* **Chores**
  * Enhanced code robustness with explicit type annotations for better reliability.
  * Introduced utility functions to support administrative maintenance and user troubleshooting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->