### PR TITLE
hotfix: Allow super-admin to create invitations without being facility member

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -142,8 +142,8 @@ service cloud.firestore {
 
       // invitations subcollection (Phase 2-3で実装予定)
       match /invitations/{invitationId} {
-        // admin以上で読み取り・作成、更新・削除はCloud Functionのみ
-        allow read, create: if isAuthenticated() && hasRole(facilityId, 'admin');
+        // super-adminまたはadmin以上で読み取り・作成、更新・削除はCloud Functionのみ
+        allow read, create: if isAuthenticated() && (isSuperAdmin() || hasRole(facilityId, 'admin'));
         allow update, delete: if false; // Cloud Functionのみ
       }
     }


### PR DESCRIPTION
## 問題
Firestore Security Rulesで、super-adminが施設メンバーでない場合に招待を作成できない権限エラーが発生していました。

```
FirebaseError: Missing or insufficient permissions.
```

## 原因
`invitations` サブコレクションのルールが `hasRole(facilityId, 'admin')` のみをチェックしていたため、super-adminでも特定の施設に登録されていない場合は招待を作成できませんでした（鶏と卵の問題）。

## 修正内容
`firestore.rules` の `invitations` サブコレクションに `isSuperAdmin()` チェックを追加：

```
allow read, create: if isAuthenticated() && (isSuperAdmin() || hasRole(facilityId, 'admin'));
```

これにより、super-adminは施設メンバーでなくても招待を作成できるようになります。

## テスト
- CodeRabbitレビュー: ✅ 通過
- Security Rules変更のみ（ロジック変更なし）

## デプロイ後の動作
Super-adminは以下が可能になります：
1. 施設詳細ページで「メンバー追加」ボタンをクリック
2. 招待を作成（権限エラーなし）
3. 招待リンクを取得
4. ユーザーを施設に招待

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded access permissions to allow super-administrators to read and create facility invitations, alongside facility administrators. Modification and deletion operations remain restricted to system processes only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->