### PR TITLE
hotfix: Use production URL for invitation links

### DIFF
--- a/src/services/invitationService.ts
+++ b/src/services/invitationService.ts
@@ -44,8 +44,8 @@ function generateUUID(): string {
  * @returns 招待リンクURL
  */
 export function generateInvitationLink(token: string): string {
-  // 本番環境のURL（環境変数から取得、デフォルトはlocalhost）
-  const baseUrl = import.meta.env.VITE_APP_URL || 'http://localhost:5173';
+  // 本番環境のURL（環境変数から取得、デフォルトは本番URL）
+  const baseUrl = import.meta.env.VITE_APP_URL || 'https://ai-care-shift-scheduler.web.app';
   return `${baseUrl}/invite?token=${token}`;
 }
 


### PR DESCRIPTION
## 問題
招待リンクが`localhost`URLを生成していたため、**クライアントにデモ操作してもらえない**という重大な問題がありました。

```
http://localhost:5173/invite?token=...
```

## 原因
`invitationService.ts`の`generateInvitationLink()`関数でデフォルトURLが`localhost`に設定されていました：

```typescript
const baseUrl = import.meta.env.VITE_APP_URL || 'http://localhost:5173';
```

## 修正内容
デフォルトURLを本番環境URLに変更：

```typescript
const baseUrl = import.meta.env.VITE_APP_URL || 'https://ai-care-shift-scheduler.web.app';
```

## 修正後の動作
招待リンクが本番環境URLで生成されるようになり、クライアントがどこからでもアクセス可能になります：

```
https://ai-care-shift-scheduler.web.app/invite?token=...
```

## テスト
- CodeRabbitレビュー: ✅ 通過
- ロジック変更のみ（Security Rules変更なし）

## 影響範囲
- ユーザー招待機能（Phase 11）
- デモンストレーションとクライアント招待が可能に

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default invitation link generation to use the production URL instead of localhost when environment configuration is not explicitly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->