### PR TITLE
hotfix: Allow invited users to update invitation status to accepted

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -142,9 +142,15 @@ service cloud.firestore {
 
       // invitations subcollection (Phase 2-3で実装予定)
       match /invitations/{invitationId} {
-        // super-adminまたはadmin以上で読み取り・作成、更新・削除はCloud Functionのみ
+        // super-adminまたはadmin以上で読み取り・作成
         allow read, create: if isAuthenticated() && (isSuperAdmin() || hasRole(facilityId, 'admin'));
-        allow update, delete: if false; // Cloud Functionのみ
+        // 招待されたユーザー本人のみ、自分の招待ステータスを 'accepted' に更新可能
+        allow update: if isAuthenticated()
+          && request.auth.token.email == resource.data.email
+          && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status'])
+          && request.resource.data.status == 'accepted';
+        // 削除はCloud Functionのみ
+        allow delete: if false;
       }
     }
 


### PR DESCRIPTION
## 問題
招待を受け入れる際に、招待ステータスを `'accepted'` に更新しようとすると権限エラーが発生していました。

```
Error accepting invitation: FirebaseError: Missing or insufficient permissions.
Error in 招待の受け入れ: {code: 'FIRESTORE_ERROR', message: '招待の受け入れに失敗しました'}
```

## 原因
Firestore Security Rulesで招待の更新が完全に禁止されていました：

```
allow update, delete: if false; // Cloud Functionのみ
```

当初Cloud Functionで処理することを想定していましたが、現在はクライアントサイドで直接処理しているため、権限エラーが発生しています。

## 修正内容
招待されたユーザー本人のみ、自分の招待ステータスを `'accepted'` に更新できるようにしました：

```
allow update: if isAuthenticated()
  && request.auth.token.email == resource.data.email
  && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status'])
  && request.resource.data.status == 'accepted';
```

### セキュリティ保護：
1. 認証済みユーザーのみ
2. 招待されたメールアドレスと一致するユーザーのみ
3. `status` フィールドのみ変更可能
4. `status` は `'accepted'` のみ設定可能

## テスト
- CodeRabbitレビュー: ✅ 通過
- Security Rules変更のみ

## 修正後の動作
招待リンクから：
1. Google OAuth認証
2. アクセス権限が付与される
3. 招待ステータスが `'accepted'` に更新される（権限エラーなし）✅
4. メイン画面にリダイレクト

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced invitation acceptance workflow by allowing users to directly update their invitation status to 'accepted' under specific security conditions (email verification and authenticated user confirmation).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->