### PR TITLE
fix: 招待受け入れ時のエラーハンドリング改善（ブラウザキャッシュ対策）

### DIFF
--- a/src/pages/InviteAccept.tsx
+++ b/src/pages/InviteAccept.tsx
@@ -20,7 +20,7 @@ export function InviteAccept(): JSX.Element {
   const [loading, setLoading] = useState(true);
   const [verifying, setVerifying] = useState(true);
   const [accepting, setAccepting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<{ message: string; canRetry: boolean } | null>(null);
   const [invitationInfo, setInvitationInfo] = useState<{
     email: string;
     role: string;
@@ -33,7 +33,7 @@ export function InviteAccept(): JSX.Element {
   useEffect(() => {
     const verifyToken = async () => {
       if (!token) {
-        setError('招待トークンが見つかりません');
+        setError({ message: '招待トークンが見つかりません', canRetry: false });
         setVerifying(false);
         setLoading(false);
         return;
@@ -44,18 +44,24 @@ export function InviteAccept(): JSX.Element {
       if (!result.success) {
         // 招待固有のエラーメッセージをユーザーフレンドリーに変換
         let friendlyMessage = '';
+        let canRetry = true;
+
         if (result.error.code === 'EXPIRED') {
           friendlyMessage = 'この招待リンクは有効期限が切れています。\n招待を送った方に新しいリンクの発行を依頼してください。';
+          canRetry = false;
         } else if (result.error.code === 'ALREADY_ACCEPTED') {
           friendlyMessage = 'この招待は既に使用されています。\n新しい招待リンクが必要な場合は、招待を送った方にご連絡ください。';
+          canRetry = false;
         } else if (result.error.code === 'NOT_FOUND') {
           friendlyMessage = 'この招待リンクは見つかりませんでした。\nリンクが正しいか確認してください。';
+          canRetry = false;
         } else {
           const errorMsg = handleError(result.error, '招待の検証');
           friendlyMessage = errorMsg.message;
+          canRetry = errorMsg.canRetry;
         }
 
-        setError(friendlyMessage);
+        setError({ message: friendlyMessage, canRetry });
         setVerifying(false);
         setLoading(false);
         return;
@@ -87,9 +93,10 @@ export function InviteAccept(): JSX.Element {
       if (
         currentUser.email?.toLowerCase() !== invitationInfo.email.toLowerCase()
       ) {
-        setError(
-          `この招待は ${invitationInfo.email} 宛です。現在ログインしているアカウント（${currentUser.email}）とは異なります。正しいアカウントでログインしてください。`
-        );
+        setError({
+          message: `この招待は ${invitationInfo.email} 宛です。現在ログインしているアカウント（${currentUser.email}）とは異なります。正しいアカウントでログインしてください。`,
+          canRetry: false,
+        });
         return;
       }
 
@@ -106,16 +113,21 @@ export function InviteAccept(): JSX.Element {
       if (!result.success) {
         // 招待受け入れ固有のエラーメッセージをユーザーフレンドリーに変換
         let friendlyMessage = '';
+        let canRetry = true;
+
         if (result.error.code === 'PERMISSION_DENIED') {
           friendlyMessage = 'アクセス権限がありません。\nページを更新してもう一度お試しください。\n問題が解決しない場合は、招待を送った方にご連絡ください。';
+          canRetry = true;
         } else if (result.error.code === 'ALREADY_HAS_ACCESS' || result.error.message?.includes('すでに')) {
           friendlyMessage = 'あなたは既にこの施設にアクセスできます。\nホーム画面から施設を選択してください。';
+          canRetry = false;
         } else {
           const errorMsg = handleError(result.error, '招待の受け入れ');
           friendlyMessage = errorMsg.message;
+          canRetry = errorMsg.canRetry;
         }
 
-        setError(friendlyMessage);
+        setError({ message: friendlyMessage, canRetry });
         return;
       }
 
@@ -133,7 +145,7 @@ export function InviteAccept(): JSX.Element {
       // ログイン後、useEffectが自動的に招待を受け入れます
     } catch (error) {
       const errorMsg = handleError(error, 'ログイン');
-      setError(errorMsg.message);
+      setError({ message: errorMsg.message, canRetry: errorMsg.canRetry });
     }
   };
 
@@ -169,21 +181,25 @@ export function InviteAccept(): JSX.Element {
               招待の処理に失敗しました
             </h1>
             <p className="text-sm text-gray-600">
-              エラーが発生しました。ページを更新してもう一度お試しください。
+              {error.canRetry 
+                ? 'エラーが発生しました。ページを更新してもう一度お試しください。'
+                : 'エラーが発生しました。詳細は下記をご確認ください。'}
             </p>
           </div>
 
           <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
-            <p className="text-sm text-red-800 whitespace-pre-wrap">{error}</p>
+            <p className="text-sm text-red-800 whitespace-pre-wrap">{error.message}</p>
           </div>
 
           <div className="space-y-3">
-            <button
-              onClick={() => window.location.reload()}
-              className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
-            >
-              ページを更新する
-            </button>
+            {error.canRetry && (
+              <button
+                onClick={() => window.location.reload()}
+                className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
+              >
+                ページを更新する
+              </button>
+            )}
             <button
               onClick={() => navigate('/')}
               className="w-full px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors font-medium"


### PR DESCRIPTION
## 概要

一般ユーザーが招待リンクからアクセスした際にブラウザキャッシュによってエラーが発生する問題に対して、ユーザーフレンドリーなエラー回復手段を提供します。

## 背景

- ユーザーから「招待の処理に失敗しました」というエラー画面が表示されるとの報告
- 原因: ブラウザキャッシュにより古いJavaScriptビルド（`index-DzD-Bcmg.js`）が実行され、新しいFirestore Security Rulesと互換性がなかった
- 技術的には hard refresh (Cmd+Shift+R) で解決できるが、一般ユーザーはこの操作方法を知らない

## 主な変更内容

### 1. リトライ機能の追加
- 「ページを更新する」ボタンを追加 (`window.location.reload()`)
- 「ホームに戻る」ボタンを追加（代替手段）

### 2. エラーメッセージの改善
招待固有のユーザーフレンドリーなエラーメッセージ:
- **EXPIRED**: 「この招待リンクは有効期限が切れています。招待を送った方に新しいリンクの発行を依頼してください。」
- **ALREADY_ACCEPTED**: 「この招待は既に使用されています。」
- **NOT_FOUND**: 「この招待リンクは見つかりませんでした。リンクが正しいか確認してください。」
- **PERMISSION_DENIED**: 「アクセス権限がありません。ページを更新してもう一度お試しください。」

### 3. 条件付きリトライUI（CodeRabbitフィードバック対応）
- エラー状態を `{ message: string; canRetry: boolean }` 型に変更
- `error.canRetry` フラグに基づいて、リトライ案内メッセージとボタンを条件付きで表示
  - **リトライ可能なエラー** (PERMISSION_DENIED、ネットワークエラーなど): リトライボタンと案内メッセージを表示
  - **リトライ不可能なエラー** (EXPIRED、ALREADY_ACCEPTED、NOT_FOUND、メールアドレス不一致など): リトライボタンを非表示、代替メッセージを表示

## テスト観点

- [ ] 招待リンクからアクセスし、エラーが発生した場合に「ページを更新する」ボタンが表示されること
- [ ] リトライボタンをクリックするとページがリロードされ、最新のJavaScriptビルドが取得されること
- [ ] 期限切れ招待の場合、リトライボタンが表示されず、適切なエラーメッセージが表示されること
- [ ] 既に受け入れ済みの招待の場合、適切なエラーメッセージが表示されること

## レビューポイント

- ユーザー体験の改善: 一般ユーザーでもエラーから回復可能
- エラーの種類に応じた適切なUI表示
- CodeRabbitレビュー完了（問題なし）

## 関連Issue

ユーザーからのフィードバック:
> でも一般ユーザーがこの画面を見たら問題ですから、どうすればよいか計画を練って対応をしてください

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages during invitation acceptance with clearer, user-friendly descriptions.
  * Added page refresh option when errors are recoverable.

* **Enhancements**
  * Enhanced error display with contextual guidance based on error type.
  * Updated UI to conditionally show retry or home navigation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->