### PR TITLE
docs: ドキュメント監査に基づく整合性修正

### DIFF
--- a/.kiro/NAVIGATION.md
+++ b/.kiro/NAVIGATION.md
@@ -1,0 +1,203 @@
+# 📚 プロジェクトドキュメントナビゲーション
+
+このドキュメントは、AIシフト自動作成プロジェクトの全ドキュメントへの索引です。
+
+## 🚀 クイックスタート
+
+| 目的 | ドキュメント |
+|-----|------------|
+| プロジェクト概要を知りたい | [`README.md`](../README.md) |
+| 開発環境を構築したい | [`README.md`](../README.md) - セットアップセクション |
+| テストを実行したい | [`README.md`](../README.md) - テストセクション |
+| デプロイしたい | [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) |
+
+---
+
+## 📋 プロジェクト管理（Steering）
+
+プロジェクト全体の方針・技術スタック・構造に関するドキュメント
+
+| ドキュメント | 内容 |
+|------------|------|
+| [`steering/product.md`](steering/product.md) | プロダクトビジョン、ビジネス要件 |
+| [`steering/tech.md`](steering/tech.md) | 技術スタック、アーキテクチャ決定 |
+| [`steering/structure.md`](steering/structure.md) | ファイル構造、コーディング規約 |
+
+---
+
+## 🎯 機能仕様（Specs）
+
+個別機能の要件・設計・実装タスクに関するドキュメント
+
+### ✅ Auth Data Persistence（認証・データ永続化）（Phase 0-13完了）
+
+**目的**: 事業所単位のマルチテナント設計、Google OAuth認証、RBAC、監査ログ
+
+| ドキュメント | 内容 |
+|------------|------|
+| [`specs/auth-data-persistence/requirements.md`](specs/auth-data-persistence/requirements.md) | 全要件の詳細定義 |
+| [`specs/auth-data-persistence/design.md`](specs/auth-data-persistence/design.md) | 技術設計、アーキテクチャ |
+| [`specs/auth-data-persistence/tasks.md`](specs/auth-data-persistence/tasks.md) | 実装タスク（Phase 0-13完了） |
+| [`specs/auth-data-persistence/phase13-completion-summary-2025-11-01.md`](specs/auth-data-persistence/phase13-completion-summary-2025-11-01.md) | **Phase 13完了サマリー** 📊 |
+| [`specs/auth-data-persistence/phase13-diagram-2025-11-01.md`](specs/auth-data-persistence/phase13-diagram-2025-11-01.md) | **Phase 13構造図（Mermaid）** 📈 |
+| [`specs/auth-data-persistence/phase0-verification-2025-10-31.md`](specs/auth-data-persistence/phase0-verification-2025-10-31.md) | Phase 0検証記録 |
+| [`specs/auth-data-persistence/deployment-summary.md`](specs/auth-data-persistence/deployment-summary.md) | デプロイサマリー |
+| [`specs/auth-data-persistence/spec.json`](specs/auth-data-persistence/spec.json) | メタデータ |
+
+**ステータス**: ✅ Phase 0-13完了（2025-11-01）
+**テスト結果**: 48/48ユニットテスト成功、100%成功率
+**カバレッジ**: Phase 13サービス 79-92% statements, 100% functions
+
+---
+
+### ✅ AI Shift Integration Test（完了）
+
+**目的**: AIシフト生成機能の動作を包括的にテスト
+
+| ドキュメント | 内容 |
+|------------|------|
+| [`specs/ai-shift-integration-test/requirements.md`](specs/ai-shift-integration-test/requirements.md) | 9要件の詳細定義 |
+| [`specs/ai-shift-integration-test/design.md`](specs/ai-shift-integration-test/design.md) | 技術設計、アーキテクチャ |
+| [`specs/ai-shift-integration-test/tasks.md`](specs/ai-shift-integration-test/tasks.md) | 実装タスク（7/7完了） |
+| [`specs/ai-shift-integration-test/IMPLEMENTATION_COMPLETE.md`](specs/ai-shift-integration-test/IMPLEMENTATION_COMPLETE.md) | **実装完了レポート** 📊 |
+| [`specs/ai-shift-integration-test/spec.json`](specs/ai-shift-integration-test/spec.json) | メタデータ |
+
+**ステータス**: ✅ 実装完了（2025-10-23）
+**テスト結果**: 37/37統合テスト成功、100%成功率
+
+---
+
+## 🏗️ アーキテクチャ概要
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    プロジェクト構成                       │
+└─────────────────────────────────────────────────────────┘
+
+Frontend (React + TypeScript)
+  ├─ src/
+  │   ├─ App.tsx              - メインアプリケーション
+  │   ├─ components/          - UIコンポーネント
+  │   └─ services/
+  │       └─ geminiService.ts - Cloud Functions API呼び出し
+  │
+  └─ e2e/                     - Playwrightテスト（E2E）
+
+Backend (Cloud Functions + Vertex AI)
+  ├─ functions/src/
+  │   ├─ index.ts             - エントリポイント
+  │   ├─ shift-generation.ts  - AIシフト生成（メイン）
+  │   ├─ phased-generation.ts - 段階的生成ロジック
+  │   └─ types.ts             - 型定義
+  │
+  └─ functions/__tests__/     - Jest統合テスト（37テスト）
+
+Infrastructure
+  ├─ Firebase Hosting         - フロントエンドホスティング
+  ├─ Cloud Functions Gen 2    - サーバーレスバックエンド
+  ├─ Firestore               - データ永続化
+  └─ Vertex AI               - Gemini 2.5 Flash-Lite
+```
+
+---
+
+## 🧪 テスト関連
+
+| テストタイプ | 場所 | 実行コマンド | ステータス |
+|------------|------|------------|-----------|
+| **ユニットテスト（Vitest）** | `src/services/__tests__/` | `npm run test:unit` | ✅ 48/48合格 (100%) |
+| 統合テスト（Jest） | `functions/__tests__/integration/` | `cd functions && npm run test:integration` | ✅ 37/37合格 (100%) |
+| E2Eテスト（Playwright） | `e2e/` | `npx playwright test` | ⏳ 後回し |
+| CI/CD | `.github/workflows/ci.yml` | 自動実行（push時） | ✅ 稼働中 |
+
+**詳細**: [`README.md`](../README.md) - 🧪 テストセクション
+
+**ユニットテストカバレッジ**:
+- `auditLogService`: 81% statements, 100% functions
+- `securityAlertService`: 79% statements, 100% functions
+- `anomalyDetectionService`: 93% statements, 100% functions
+- `staffService`: 66% statements, 88% functions
+- `scheduleService`: 18% statements, 29% functions（要改善）
+
+---
+
+## 🔧 技術スタック（クイックリファレンス）
+
+| カテゴリ | 技術 |
+|---------|------|
+| **フロントエンド** | React 19, TypeScript 5.8, Vite 6 |
+| **バックエンド** | Node.js 20, Cloud Functions Gen 2 |
+| **AI** | Vertex AI Gemini 2.5 Flash-Lite（us-central1） |
+| **データベース** | Firestore |
+| **テスト** | Jest, Playwright, Supertest |
+| **CI/CD** | GitHub Actions, Firebase CLI |
+
+**詳細**: [`steering/tech.md`](steering/tech.md)
+
+---
+
+## 📝 重要な技術的決定
+
+### Gemini モデルとリージョン
+
+⚠️ **CRITICAL**: 以下の設定は変更しないこと
+
+- **モデル名**: `gemini-2.5-flash-lite` （`-latest` サフィックスなし、GA安定版）
+- **リージョン**: `us-central1` （このモデルが動作する唯一のリージョン）
+
+**詳細**: [`specs/ai-shift-integration-test/IMPLEMENTATION_COMPLETE.md`](specs/ai-shift-integration-test/IMPLEMENTATION_COMPLETE.md) - 課題1
+
+### 段階的生成アプローチ
+
+大規模スタッフ（11名以上）に対して2段階生成を実施：
+
+1. **Phase 1**: 骨子生成（休日・夜勤パターン）
+2. **Phase 2**: 詳細生成（10名/バッチ）
+
+**詳細**: [`specs/ai-shift-integration-test/IMPLEMENTATION_COMPLETE.md`](specs/ai-shift-integration-test/IMPLEMENTATION_COMPLETE.md) - 課題3
+
+---
+
+## 🆘 トラブルシューティング
+
+問題が発生した場合の参照先：
+
+1. **テスト実行エラー**: [`README.md`](../README.md) - トラブルシューティングセクション
+2. **AI生成エラー**: [`specs/ai-shift-integration-test/IMPLEMENTATION_COMPLETE.md`](specs/ai-shift-integration-test/IMPLEMENTATION_COMPLETE.md) - 技術的課題セクション
+3. **デプロイエラー**: [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) のログ確認
+
+---
+
+## 🎓 新規開発者向けオンボーディング
+
+### 1日目: プロジェクト理解
+
+1. [`README.md`](../README.md) を読む（15分）
+2. [`steering/product.md`](steering/product.md) でビジネス要件を理解（10分）
+3. [`steering/tech.md`](steering/tech.md) で技術スタックを把握（10分）
+4. 本番環境を触る: https://ai-care-shift-scheduler.web.app （10分）
+
+### 2日目: 開発環境構築
+
+1. [`README.md`](../README.md) のセットアップ手順に従う（30分）
+2. ローカル開発サーバー起動（5分）
+3. テスト実行（`npm run test:integration`）（5分）
+
+### 3日目: コード理解
+
+1. [`specs/ai-shift-integration-test/design.md`](specs/ai-shift-integration-test/design.md) でアーキテクチャ理解（20分）
+2. フロントエンドコード読解（`src/App.tsx`, `services/geminiService.ts`）（30分）
+3. バックエンドコード読解（`functions/src/shift-generation.ts`）（30分）
+
+---
+
+## 📞 サポート
+
+- **GitHub Issues**: https://github.com/yasushi-honda/ai-care-shift-scheduler/issues
+- **リポジトリ**: https://github.com/yasushi-honda/ai-care-shift-scheduler
+
+---
+
+**最終更新**: 2025-11-01
+**バージョン**: 1.1
+**メンテナ**: 開発チーム

--- a/.kiro/specs/INDEX.md
+++ b/.kiro/specs/INDEX.md
@@ -1,0 +1,80 @@
+# Specifications Index
+
+**最終更新**: 2026-01-22
+
+このドキュメントは `.kiro/specs/` 配下の全仕様の索引です。
+
+---
+
+## 完了済み Specs
+
+| Spec | Phase | Status | 概要 |
+|------|-------|--------|------|
+| [ai-shift-integration-test](./ai-shift-integration-test/) | - | ✅ 完了 | AIシフト生成の統合テスト |
+| [auth-data-persistence](./auth-data-persistence/) | 0-12.5 | ✅ 完了 | 認証・データ永続化・RBAC |
+| [monthly-report-enhancement](./monthly-report-enhancement/) | 41 | ✅ 完了 | 月次レポート機能強化 |
+| [ui-design-improvement](./ui-design-improvement/) | 42 | ✅ 完了 | UI/UXデザイン改善 |
+| [navigation-improvement](./navigation-improvement/) | 42.1 | ✅ 完了 | ナビゲーション改善 |
+| [demo-login](./demo-login/) | 42.2 | ✅ 完了 | デモログイン機能 |
+| [demo-environment-improvements](./demo-environment-improvements/) | 43 | ✅ 完了 | デモ環境改善 |
+| [ai-evaluation-feedback](./ai-evaluation-feedback/) | 44 | ✅ 完了 | AI評価フィードバック |
+| [ai-generation-progress](./ai-generation-progress/) | 45 | ✅ 完了 | AI生成進行状況表示 |
+| [constraint-level-evaluation](./constraint-level-evaluation/) | 53 | ✅ 完了 | 4段階制約レベル評価 |
+| [evaluation-history-reevaluate](./evaluation-history-reevaluate/) | 54 | ✅ 完了 | 評価履歴・再評価機能 |
+| [data-configuration-diagnosis](./data-configuration-diagnosis/) | 55 | ✅ 完了 | データ設定診断機能 |
+
+---
+
+## 未完了 / 計画中 Specs
+
+| Spec | Status | 概要 |
+|------|--------|------|
+| [care-staff-schedule-compliance](./care-staff-schedule-compliance/) | 📋 計画中 | 介護スタッフスケジュールコンプライアンス |
+| [leave-balance-management](./leave-balance-management/) | 📋 計画中 | 休暇残高管理 |
+| [shift-type-settings](./shift-type-settings/) | 📋 計画中 | シフトタイプ設定 |
+
+---
+
+## キーボードアクセシビリティ Specs（未実装）
+
+| Spec | Status | 概要 |
+|------|--------|------|
+| [arrow-key-navigation](./arrow-key-navigation/) | ⏸️ 保留 | 矢印キーナビゲーション |
+| [ctrl-arrow-navigation](./ctrl-arrow-navigation/) | ⏸️ 保留 | Ctrl+矢印ナビゲーション |
+| [home-end-navigation](./home-end-navigation/) | ⏸️ 保留 | Home/Endキーナビゲーション |
+| [pageup-pagedown-navigation](./pageup-pagedown-navigation/) | ⏸️ 保留 | PageUp/PageDownナビゲーション |
+| [keyboard-accessibility](./keyboard-accessibility/) | ⏸️ 保留 | キーボードアクセシビリティ全般 |
+| [keyboard-shortcut-help](./keyboard-shortcut-help/) | ⏸️ 保留 | キーボードショートカットヘルプ |
+
+---
+
+## その他 Specs
+
+| Spec | Status | 概要 |
+|------|--------|------|
+| [ci-cd-e2e-integration](./ci-cd-e2e-integration/) | ⏸️ 保留 | CI/CD E2E統合 |
+| [demo-data-improvement](./demo-data-improvement/) | ⏸️ 保留 | デモデータ改善 |
+| [demo-shift-removal](./demo-shift-removal/) | ⏸️ 保留 | デモシフト削除 |
+| [double-click-shift-edit](./double-click-shift-edit/) | ⏸️ 保留 | ダブルクリックシフト編集 |
+| [github-pages-optimization](./github-pages-optimization/) | ⏸️ 保留 | GitHub Pages最適化 |
+| [mobile-touch-support](./mobile-touch-support/) | ⏸️ 保留 | モバイルタッチサポート |
+| [redo-functionality](./redo-functionality/) | ⏸️ 保留 | やり直し機能 |
+| [undo-functionality](./undo-functionality/) | ⏸️ 保留 | 元に戻す機能 |
+
+---
+
+## ステータス凡例
+
+| アイコン | 意味 |
+|---------|------|
+| ✅ | 完了 |
+| 🚧 | 進行中 |
+| 📋 | 計画中 |
+| ⏸️ | 保留 |
+
+---
+
+## 関連ドキュメント
+
+- [CLAUDE.md](../../CLAUDE.md) - Active Specifications一覧
+- [NAVIGATION.md](../NAVIGATION.md) - ドキュメントナビゲーション

--- a/README.md
+++ b/README.md
@@ -145,10 +145,17 @@ ai-care-shift-scheduler/
 │   │   ├── architecture.md
 │   │   ├── structure.md
 │   │   └── implementation-log.md
-│   └── specs/            # 機能仕様（将来使用）
-├── components/           # Reactコンポーネント
+│   └── specs/            # 機能仕様
+├── src/                  # フロントエンドソース
+│   ├── components/       # 追加UIコンポーネント
+│   ├── services/         # フロントエンドサービス
+│   ├── contexts/         # React Context
+│   ├── hooks/            # カスタムフック
+│   └── pages/            # ページコンポーネント
+├── components/           # Reactコンポーネント（共通）
 ├── services/             # ビジネスロジック
 ├── functions/            # Cloud Functions
+├── e2e/                  # Playwrightテスト
 ├── public/               # 静的ファイル
 ├── App.tsx               # ルートコンポーネント
 ├── types.ts              # TypeScript型定義
@@ -209,9 +216,9 @@ ai-care-shift-scheduler/
 
 詳細は [.kiro/steering/tech.md](.kiro/steering/tech.md) を参照してください。
 
-## 📖 ドキュメント
+## 📖 Steeringファイル詳細
 
-### Steering（プロジェクト方針）
+### プロジェクト方針
 - [product.md](.kiro/steering/product.md) - プロダクトコンテキストとビジネス目標
 - [tech.md](.kiro/steering/tech.md) - 技術スタックと技術的決定
 - [architecture.md](.kiro/steering/architecture.md) - システムアーキテクチャ
@@ -448,7 +455,7 @@ gcloud services enable aiplatform.googleapis.com --project=ai-care-shift-schedul
 
 **対応**: ブラウザのキャッシュをクリアするか、次回デプロイ時に自然に更新されます。
 
-詳細は [Phase 1-3 デプロイ完了サマリー](.kiro/specs/auth-data-persistence/deployment-summary.md#既知の問題非クリティカル) を参照してください。
+詳細は [Phase 1-3 デプロイ完了サマリー](.kiro/specs/auth-data-persistence/archive/deployment-summary.md#既知の問題非クリティカル) を参照してください。
 
 ## 🗓️ ロードマップ
 
@@ -466,7 +473,7 @@ gcloud services enable aiplatform.googleapis.com --project=ai-care-shift-schedul
 - ✅ Firestore Security Rulesによるアクセス制御
 - ✅ CI/CD（GitHub Actions → Firebase）の自動デプロイ
 
-**詳細**: [Phase 1-3 デプロイ完了サマリー](.kiro/specs/auth-data-persistence/deployment-summary.md)
+**詳細**: [Phase 1-3 デプロイ完了サマリー](.kiro/specs/auth-data-persistence/archive/deployment-summary.md)
 
 ### Phase 4: データ永続化 - 2026年Q1（進行中）
 - スタッフ情報のFirestore永続化


### PR DESCRIPTION
## Summary

- NAVIGATION.mdをarchiveから復元（リンク切れ解消）
- specs/INDEX.md新規作成（全29 specsの索引・ステータス一覧）
- README.mdのリンク切れ4件を修正
- README.mdの重複「ドキュメント」セクションを統合
- README.mdのプロジェクト構造を現状（src/配下追加）に更新

## Background

`/doc-audit`コマンドによるドキュメント監査で以下の問題を検出:
- README.mdに4件のリンク切れ
- ドキュメントセクションの重複（行33と212）
- プロジェクト構造の記載が古い
- specs/の索引が不在

## Test plan

- [ ] NAVIGATION.mdへのリンクが有効か確認
- [ ] deployment-summary.mdへのリンクが有効か確認
- [ ] specs/INDEX.mdの内容がCLAUDE.mdと整合しているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)