### PR TITLE
fix: 看護師配置制約のバランス調整（人員不足対策）

### DIFF
--- a/functions/src/phased-generation.ts
+++ b/functions/src/phased-generation.ts
@@ -1360,24 +1360,20 @@ function buildDetailedDynamicConstraints(
     )?.count || 1;
 
     const rules: string[] = [];
-    rules.push(`1. 看護師は出勤日に**原則「日勤」**を割り当ててください`);
 
     if (nurses.length > requiredCount) {
-      const canRedeploy = nurses.length - requiredCount;
-      rules.push(`2. ${nurses.length}名の看護師が同日に出勤する場合のみ、${canRedeploy}名まで早番・遅番に配置可`);
-      rules.push(`3. 出勤する看護師が${requiredCount}名の日は、その看護師は**必ず「日勤」**`);
+      rules.push(`- ${nurses.length}名の看護師が同日に出勤する日: ${requiredCount}名を日勤、残り${nurses.length - requiredCount}名は早番・日勤・遅番のいずれかに自由に配置`);
+      rules.push(`- 出勤する看護師が${requiredCount}名の日: その看護師を**必ず日勤**に配置`);
     } else {
-      rules.push(`2. 看護師は全員、出勤日は**必ず「日勤」**（早番・遅番への配置は禁止）`);
+      rules.push(`- 看護師は全員、出勤日は**必ず「日勤」**に配置`);
     }
 
     constraints.push(
-      `## 🔴 【看護師日勤配置 - 最優先制約】\n` +
-      `日勤の資格要件: 毎営業日、看護師**${requiredCount}名以上**が必須（法定基準）\n` +
+      `## 🔴 【看護師日勤配置】\n` +
+      `毎営業日の日勤に看護師**${requiredCount}名以上**が必要です（法定基準）。\n` +
       `対象看護師: ${nurseNames}（計${nurses.length}名）\n\n` +
-      `**配置ルール（必ず遵守）:**\n` +
       rules.join('\n') +
-      `\n\n⚠️ この制約はシフトバランス配分より優先されます。\n` +
-      `看護師が日勤に${requiredCount}名もいない営業日がある場合、そのシフトは無効です。`
+      `\n\n看護師が日勤に${requiredCount}名もいない営業日がある場合、資格要件違反です。`
     );
   }
 


### PR DESCRIPTION
## Summary
- PR #53の看護師制約が強すぎて早番/遅番が人員不足になった問題を修正
- 「全員原則日勤」→「毎日最低1名が日勤、残りは自由配置」に変更

## Background
PR #53で看護師制約を🔴最優先に格上げした結果:
- 必要資格不足は解消方向だが、人員不足が1件→11件に悪化（30点）
- AIが「原則日勤」を全看護師の日勤固定と解釈
- 早番/遅番に回す人員が不足、人員充足率99%→92%に低下

## Changes
- 「原則日勤」の文言を削除
- 「シフトバランス配分より優先」の文言を削除
- 2名看護師が同日出勤: 1名を日勤、残り1名は早番・日勤・遅番のいずれかに自由配置
- 1名のみ出勤: 必ず日勤

## Test plan
- [x] TypeScript型チェック通過
- [x] 既存ユニットテスト23件全て合格
- [ ] デモ環境でシフト再生成し人員不足と必要資格不足の両方が改善されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised nursing shift scheduling messages and requirements descriptions, including updated formatting, modified headers, and refined error messaging to improve clarity in constraint communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->