### PR TITLE
feat: リバランスに資格要件ベースのスワップを追加（必要資格不足の決定論的修正）

### DIFF
--- a/functions/__tests__/unit/shiftRebalance.test.ts
+++ b/functions/__tests__/unit/shiftRebalance.test.ts
@@ -5,16 +5,19 @@
  * - getDailyShiftCount: 日別シフト集計
  * - countViolations: 違反カウント
  * - formatRebalanceLog: ログフォーマット
+ * - rebalanceQualifications: 資格要件ベースのリバランス
  */
 
 import { STANDARD_STAFF_LIST } from '../fixtures/test-data';
-import { TimeSlotPreference } from '../../src/types';
+import { Qualification, Role, TimeSlotPreference } from '../../src/types';
+import type { Staff, ShiftRequirement, StaffSchedule } from '../../src/types';
 
 // shift-rebalance.tsから関数をインポート
 import {
   formatRebalanceLog,
   getDailyShiftCount,
   countViolations,
+  rebalanceQualifications,
 } from '../../src/shift-rebalance';
 
 describe('shift-rebalance', () => {
@@ -274,5 +277,246 @@ describe('shift-rebalance data validation', () => {
     expect(staffList[0].timeSlotPreference).toBe(TimeSlotPreference.Any);
     expect(staffList[1].timeSlotPreference).toBe(TimeSlotPreference.DayOnly);
     expect(staffList[2].timeSlotPreference).toBe(TimeSlotPreference.NightOnly);
+  });
+});
+
+// ============================================================
+// rebalanceQualifications テスト
+// ============================================================
+
+/** テスト用ヘルパー: 最小限のStaffオブジェクトを生成 */
+function makeStaff(id: string, name: string, qualifications: Qualification[], pref = TimeSlotPreference.Any): Staff {
+  return {
+    id, name, role: Role.CareWorker, qualifications,
+    weeklyWorkCount: { hope: 5, must: 4 }, maxConsecutiveWorkDays: 5,
+    availableWeekdays: [0,1,2,3,4,5,6], unavailableDates: [],
+    timeSlotPreference: pref, isNightShiftOnly: false,
+  };
+}
+
+/** テスト用ヘルパー: 1日分のスケジュールを生成 */
+function makeSchedule(staffId: string, staffName: string, date: string, shiftType: string): StaffSchedule {
+  return { staffId, staffName, monthlyShifts: [{ date, shiftType }] };
+}
+
+/** デイサービス用の標準要件（早番2, 日勤2(看護師1), 遅番1）*/
+function makeDayServiceRequirements(month = '2025-03'): ShiftRequirement {
+  return {
+    targetMonth: month,
+    timeSlots: [
+      { name: '早番', start: '08:00', end: '17:00', restHours: 1 },
+      { name: '日勤', start: '09:00', end: '18:00', restHours: 1 },
+      { name: '遅番', start: '10:00', end: '19:00', restHours: 1 },
+    ],
+    requirements: {
+      早番: { totalStaff: 2, requiredQualifications: [], requiredRoles: [] },
+      日勤: {
+        totalStaff: 2,
+        requiredQualifications: [{ qualification: Qualification.RegisteredNurse, count: 1 }],
+        requiredRoles: [],
+      },
+      遅番: { totalStaff: 1, requiredQualifications: [], requiredRoles: [] },
+    },
+  };
+}
+
+describe('rebalanceQualifications', () => {
+  const DATE = '2025-03-03'; // 月曜日
+
+  it('看護師が早番にいて日勤に看護師なし → 非看護師とスワップして日勤に配置', () => {
+    const nurse = makeStaff('nurse-1', '佐藤花子', [Qualification.RegisteredNurse]);
+    const carer1 = makeStaff('carer-1', '田中太郎', [Qualification.CertifiedCareWorker]);
+    const carer2 = makeStaff('carer-2', '山田一郎', [Qualification.CertifiedCareWorker]);
+    const staffList = [nurse, carer1, carer2];
+
+    const schedules: StaffSchedule[] = [
+      makeSchedule('nurse-1', '佐藤花子', DATE, '早番'),
+      makeSchedule('carer-1', '田中太郎', DATE, '日勤'),
+      makeSchedule('carer-2', '山田一郎', DATE, '遅番'),
+    ];
+
+    const requirements = makeDayServiceRequirements();
+    const swapLog: any[] = [];
+
+    const swaps = rebalanceQualifications(schedules, requirements, staffList, [2,9,16,23,30], false, swapLog);
+
+    expect(swaps).toBe(1);
+    // 看護師が日勤に移動
+    const nurseShift = schedules.find(s => s.staffId === 'nurse-1')!.monthlyShifts[0].shiftType;
+    expect(nurseShift).toBe('日勤');
+    // 元日勤の人が早番に移動
+    const carerShift = schedules.find(s => s.staffId === 'carer-1')!.monthlyShifts[0].shiftType;
+    expect(carerShift).toBe('早番');
+    // スワップログに記録
+    expect(swapLog).toHaveLength(1);
+    expect(swapLog[0].staffId).toBe('nurse-1');
+  });
+
+  it('看護師が既に日勤にいる → スワップ不要', () => {
+    const nurse = makeStaff('nurse-1', '佐藤花子', [Qualification.RegisteredNurse]);
+    const carer1 = makeStaff('carer-1', '田中太郎', [Qualification.CertifiedCareWorker]);
+    const staffList = [nurse, carer1];
+
+    const schedules: StaffSchedule[] = [
+      makeSchedule('nurse-1', '佐藤花子', DATE, '日勤'),
+      makeSchedule('carer-1', '田中太郎', DATE, '早番'),
+    ];
+
+    const requirements = makeDayServiceRequirements();
+    const swapLog: any[] = [];
+
+    const swaps = rebalanceQualifications(schedules, requirements, staffList, [2,9,16,23,30], false, swapLog);
+
+    expect(swaps).toBe(0);
+    expect(swapLog).toHaveLength(0);
+  });
+
+  it('資格要件がないシフト → スワップ不要', () => {
+    const nurse = makeStaff('nurse-1', '佐藤花子', [Qualification.RegisteredNurse]);
+    const staffList = [nurse];
+
+    const schedules: StaffSchedule[] = [
+      makeSchedule('nurse-1', '佐藤花子', DATE, '早番'),
+    ];
+
+    // 資格要件なしの要件
+    const requirements: ShiftRequirement = {
+      targetMonth: '2025-03',
+      timeSlots: [{ name: '早番', start: '08:00', end: '17:00', restHours: 1 }],
+      requirements: {
+        早番: { totalStaff: 1, requiredQualifications: [], requiredRoles: [] },
+      },
+    };
+    const swapLog: any[] = [];
+
+    const swaps = rebalanceQualifications(schedules, requirements, staffList, [2,9,16,23,30], false, swapLog);
+
+    expect(swaps).toBe(0);
+  });
+
+  it('看護師が全員休みの日 → スワップ候補なし', () => {
+    const nurse = makeStaff('nurse-1', '佐藤花子', [Qualification.RegisteredNurse]);
+    const carer1 = makeStaff('carer-1', '田中太郎', [Qualification.CertifiedCareWorker]);
+    const staffList = [nurse, carer1];
+
+    const schedules: StaffSchedule[] = [
+      makeSchedule('nurse-1', '佐藤花子', DATE, '休'),
+      makeSchedule('carer-1', '田中太郎', DATE, '日勤'),
+    ];
+
+    const requirements = makeDayServiceRequirements();
+    const swapLog: any[] = [];
+
+    const swaps = rebalanceQualifications(schedules, requirements, staffList, [2,9,16,23,30], false, swapLog);
+
+    expect(swaps).toBe(0);
+  });
+
+  it('日勤のみスタッフは早番/遅番にスワップされない', () => {
+    const nurse = makeStaff('nurse-1', '佐藤花子', [Qualification.RegisteredNurse]);
+    const dayOnly = makeStaff('day-only', '田中太郎', [Qualification.CertifiedCareWorker], TimeSlotPreference.DayOnly);
+    const carer = makeStaff('carer-1', '山田一郎', [Qualification.CertifiedCareWorker]);
+    const staffList = [nurse, dayOnly, carer];
+
+    const schedules: StaffSchedule[] = [
+      makeSchedule('nurse-1', '佐藤花子', DATE, '早番'),
+      makeSchedule('day-only', '田中太郎', DATE, '日勤'),
+      makeSchedule('carer-1', '山田一郎', DATE, '遅番'),
+    ];
+
+    const requirements = makeDayServiceRequirements();
+    const swapLog: any[] = [];
+
+    const swaps = rebalanceQualifications(schedules, requirements, staffList, [2,9,16,23,30], false, swapLog);
+
+    // 日勤のみスタッフは早番にスワップされない
+    const dayOnlyShift = schedules.find(s => s.staffId === 'day-only')!.monthlyShifts[0].shiftType;
+    expect(dayOnlyShift).toBe('日勤');
+    // 代わりに遅番の山田が早番にスワップされるか、スワップ不能（遅番→早番は可能）
+    // 看護師は日勤に入るべき
+    if (swaps > 0) {
+      const nurseShift = schedules.find(s => s.staffId === 'nurse-1')!.monthlyShifts[0].shiftType;
+      expect(nurseShift).toBe('日勤');
+    }
+  });
+
+  it('2名の看護師が早番/遅番にいて日勤に1名必要 → 1名のみスワップ', () => {
+    const nurse1 = makeStaff('nurse-1', '佐藤花子', [Qualification.RegisteredNurse]);
+    const nurse2 = makeStaff('nurse-2', '鈴木美咲', [Qualification.RegisteredNurse]);
+    const carer1 = makeStaff('carer-1', '田中太郎', [Qualification.CertifiedCareWorker]);
+    const carer2 = makeStaff('carer-2', '山田一郎', [Qualification.CertifiedCareWorker]);
+    const staffList = [nurse1, nurse2, carer1, carer2];
+
+    const schedules: StaffSchedule[] = [
+      makeSchedule('nurse-1', '佐藤花子', DATE, '早番'),
+      makeSchedule('nurse-2', '鈴木美咲', DATE, '遅番'),
+      makeSchedule('carer-1', '田中太郎', DATE, '日勤'),
+      makeSchedule('carer-2', '山田一郎', DATE, '日勤'),
+    ];
+
+    const requirements = makeDayServiceRequirements();
+    const swapLog: any[] = [];
+
+    const swaps = rebalanceQualifications(schedules, requirements, staffList, [2,9,16,23,30], false, swapLog);
+
+    expect(swaps).toBe(1);
+    // 日勤に看護師が1名いることを確認
+    const dayShiftStaff = schedules.filter(s => s.monthlyShifts[0].shiftType === '日勤').map(s => s.staffId);
+    const nursesOnDay = dayShiftStaff.filter(id => id.startsWith('nurse-'));
+    expect(nursesOnDay.length).toBe(1);
+  });
+
+  it('日曜日は夜勤なし施設でスキップされる', () => {
+    const nurse = makeStaff('nurse-1', '佐藤花子', [Qualification.RegisteredNurse]);
+    const carer = makeStaff('carer-1', '田中太郎', [Qualification.CertifiedCareWorker]);
+    const staffList = [nurse, carer];
+
+    // 3/2(日)のスケジュール
+    const sundayDate = '2025-03-02';
+    const schedules: StaffSchedule[] = [
+      makeSchedule('nurse-1', '佐藤花子', sundayDate, '早番'),
+      makeSchedule('carer-1', '田中太郎', sundayDate, '日勤'),
+    ];
+
+    const requirements = makeDayServiceRequirements();
+    const swapLog: any[] = [];
+
+    const swaps = rebalanceQualifications(schedules, requirements, staffList, [2,9,16,23,30], false, swapLog);
+
+    expect(swaps).toBe(0); // 日曜はスキップ
+  });
+
+  it('准看護師も看護師要件を満たせる（要件が准看護師の場合）', () => {
+    const lpn = makeStaff('lpn-1', '高橋准看', [Qualification.LicensedPracticalNurse]);
+    const carer = makeStaff('carer-1', '田中太郎', [Qualification.CertifiedCareWorker]);
+    const staffList = [lpn, carer];
+
+    const schedules: StaffSchedule[] = [
+      makeSchedule('lpn-1', '高橋准看', DATE, '早番'),
+      makeSchedule('carer-1', '田中太郎', DATE, '日勤'),
+    ];
+
+    // 准看護師要件
+    const requirements: ShiftRequirement = {
+      targetMonth: '2025-03',
+      timeSlots: [
+        { name: '早番', start: '08:00', end: '17:00', restHours: 1 },
+        { name: '日勤', start: '09:00', end: '18:00', restHours: 1 },
+      ],
+      requirements: {
+        早番: { totalStaff: 1, requiredQualifications: [], requiredRoles: [] },
+        日勤: {
+          totalStaff: 1,
+          requiredQualifications: [{ qualification: Qualification.LicensedPracticalNurse, count: 1 }],
+          requiredRoles: [],
+        },
+      },
+    };
+    const swapLog: any[] = [];
+
+    const swaps = rebalanceQualifications(schedules, requirements, staffList, [2,9,16,23,30], false, swapLog);
+
+    expect(swaps).toBe(1);
+    expect(schedules.find(s => s.staffId === 'lpn-1')!.monthlyShifts[0].shiftType).toBe('日勤');
   });
 });


### PR DESCRIPTION
## Summary
- Phase 2後処理のリバランスに、資格要件ベースの相互スワップ機能を追加
- AIのプロンプト遵守に依存せず、決定論的に看護師配置を保証

## Background
PR #52-#54でプロンプト改善を試みたが、AIの遵守率が不安定:
- PR #52: 必要資格不足12件（看護師が早番/遅番に配置される）
- PR #53: 人員不足11件に悪化（全看護師が日勤固定→他シフト不足）
- PR #54: バランス調整するもAI依存のため効果が不確実

## Approach
既存の `shift-rebalance.ts`（シフト人数バランスの後処理）に、
資格要件チェックのパスを追加:

1. 各営業日・各シフトの資格要件をチェック
2. 不足があれば、他シフトにいる有資格者と対象シフトの無資格者を**相互スワップ**
3. timeSlotPreference保護（日勤のみスタッフを早番/遅番に移動しない）
4. シフト人数バランスは維持（相互スワップのため）

## Test Results
- 新規テスト8件追加（`rebalanceQualifications`）
- 既存テスト11件を含む全19件パス（shiftRebalance.test.ts）
- **全350テスト合格**（17テストスイート全パス、既存影響なし）

### テストケース
| # | テスト | 結果 |
|---|--------|------|
| 1 | 看護師が早番→日勤にスワップ | ✅ |
| 2 | 看護師が既に日勤→スワップ不要 | ✅ |
| 3 | 資格要件なし→スワップ不要 | ✅ |
| 4 | 看護師全員休み→候補なし | ✅ |
| 5 | 日勤のみスタッフの保護 | ✅ |
| 6 | 2名看護師→1名のみスワップ | ✅ |
| 7 | 日曜スキップ | ✅ |
| 8 | 准看護師の要件充足 | ✅ |

## Test plan
- [x] TypeScript型チェック通過
- [x] 全350ユニットテスト合格
- [ ] デモ環境でシフト再生成し必要資格不足の解消を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Shift rebalancing now evaluates staff qualifications and automatically adjusts assignments to meet credential requirements. The system intelligently swaps qualified and unqualified staff members across shifts to satisfy daily qualification mandates while preserving balanced team coverage and shift distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->