### PR TITLE
fix: Solver Functions デプロイ用venv環境構築を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,6 +378,12 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Solver用venv作成と依存関係インストール
+        run: |
+          cd solver-functions
+          python3.12 -m venv venv
+          venv/bin/pip install -r requirements.txt
+
       - name: プロダクションビルド（Firebase環境変数付き）
         run: npm run build
         env:

--- a/firebase.json
+++ b/firebase.json
@@ -29,7 +29,7 @@
         "tests"
       ],
       "predeploy": [
-        "python -m pip install -r \"$RESOURCE_DIR/requirements.txt\""
+        "cd \"$RESOURCE_DIR\" && python3.12 -m venv venv && venv/bin/pip install -r requirements.txt"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- Firebase CLIがPython Functionsデプロイ時に要求するvenv環境を構築
- PR #60のpredeploy修正に加え、venv未作成エラーを解決

## 原因
Firebase CLI は Python Functions のソースコード解析時に `solver-functions/venv` ディレクトリ内の仮想環境を要求する。CI環境にはvenvが存在せず、以下のエラーでデプロイ失敗:
```
Error: Failed to find location of Firebase Functions SDK: 
Missing virtual environment at venv directory. 
Did you forget to run 'python3.12 -m venv venv'?
```

## 修正内容
- `firebase.json`: predeploy で `$RESOURCE_DIR` に cd → venv 作成 → pip install
- `ci.yml`: deploy ジョブに venv 作成ステップを追加（predeploy前に準備）

## Test plan
- [ ] CI/CDで Functions デプロイが成功すること
- [ ] `solverGenerateShift` 関数がデプロイされること
- [ ] Node.js Functions も正常にデプロイされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline and deployment configuration with isolated Python virtual environments, improving dependency isolation and build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->