### PR TITLE
fix: vitestがfunctions/のJestテストを誤検出する問題を修正

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,6 +56,8 @@ export default defineConfig(({ mode }) => {
         globals: true,
         environment: 'happy-dom',
         setupFiles: './src/test/setup.ts',
+        include: ['src/**/*.test.{ts,tsx}'],
+        exclude: ['node_modules', 'functions', 'dist', 'solver-functions'],
         coverage: {
           provider: 'v8',
           reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary
- vite.config.tsのtest設定に`include`/`exclude`を追加
- vitestが`src/`配下のテストのみを実行するよう制限
- `functions/`内のJest専用テスト26ファイルが「jest is not defined」で失敗していた問題を解消

## 変更内容
- `include: ['src/**/*.test.{ts,tsx}']` でsrc配下に限定
- `exclude: ['node_modules', 'functions', 'dist', 'solver-functions']` で不要ディレクトリを除外

## Test plan
- [x] `npm run test:unit` → 11ファイル164テスト全通過
- [x] `npx tsc --noEmit` → 型チェック通過
- [x] `npx vite build` → ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refines test discovery to only pick up TypeScript test files.
  * Excludes dependency, build, and utility directories from test runs.
  * Improves test run reliability and reduces noise, speeding up local and CI testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->