### PR TITLE
fix: Firebase Emulator functions対応とTimestamp互換性修正

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -29,7 +29,7 @@
         "tests"
       ],
       "predeploy": [
-        "cd \"$RESOURCE_DIR\" && python3.12 -m venv venv && venv/bin/pip install -r requirements.txt"
+        "command -v python3.12 >/dev/null 2>&1 && cd \"$RESOURCE_DIR\" && python3.12 -m venv venv && venv/bin/pip install -r requirements.txt || echo 'SKIP: python3.12 not found (solver-functions predeploy skipped)'"
       ]
     }
   ],
@@ -82,6 +82,9 @@
   "emulators": {
     "auth": {
       "port": 9099
+    },
+    "functions": {
+      "port": 5001
     },
     "firestore": {
       "port": 8080

--- a/functions/src/demoSignIn.ts
+++ b/functions/src/demoSignIn.ts
@@ -11,6 +11,7 @@
 
 import { onRequest } from 'firebase-functions/v2/https';
 import * as admin from 'firebase-admin';
+import { Timestamp } from 'firebase-admin/firestore';
 
 // デモアカウント設定（サーバーサイドでのみ保持）
 const DEMO_USER_UID = 'demo-user-fixed-uid';
@@ -72,7 +73,7 @@ export const demoSignIn = onRequest({
 
     // Firestoreにユーザードキュメントを作成/更新
     // レースコンディション対策: set with mergeを使用
-    const now = admin.firestore.Timestamp.now();
+    const now = Timestamp.now();
     const userRef = db.collection('users').doc(DEMO_USER_UID);
 
     console.log('🔄 demoSignIn: Creating/updating user document...');

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "seed:demo": "tsx scripts/seedDemoData.ts",
     "seed:demo:reset": "tsx scripts/seedDemoData.ts --reset",
     "cleanup:deleted-users": "tsx scripts/cleanupDeletedUsers.ts",
-    "emulators": "firebase emulators:start --only auth,firestore",
+    "emulators": "firebase emulators:start --only auth,firestore,functions",
     "emulators:auth": "firebase emulators:start --only auth",
-    "emulators:exec": "firebase emulators:exec --only auth,firestore"
+    "emulators:exec": "firebase emulators:exec --only auth,firestore,functions"
   },
   "dependencies": {
     "@google/genai": "^1.22.0",


### PR DESCRIPTION
## Summary
- Firebase Emulatorにfunctions（port 5001）を追加し、ローカルでデモログインが動作するよう修正
- solver-functions predeployにPython 3.12存在チェックを追加し、ローカル環境での起動失敗を防止
- `demoSignIn.ts`の`admin.firestore.Timestamp`をモジュラーインポートに修正（firebase-admin v13 Emulator互換性）

## Test plan
- [x] `npm run emulators` でAuth/Firestore/Functions 3つのEmulatorが正常起動
- [x] `npm run dev` + ブラウザでデモログインが成功
- [x] `cd functions && npm run build` で型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced local development environment with Firebase Functions emulator support on port 5001.
  * Improved emulator setup scripts with Python version validation to ensure compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->