### PR TITLE
chore: firebase-functions v6→v7, uuid→crypto.randomUUID()に置換

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -12,8 +12,7 @@
         "@google-cloud/vertexai": "^1.10.0",
         "@google/genai": "^1.41.0",
         "firebase-admin": "^13.6.1",
-        "firebase-functions": "^6.6.0",
-        "uuid": "^11.1.0"
+        "firebase-functions": "^7.0.5"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -3555,9 +3554,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.6.0.tgz",
-      "integrity": "sha512-wwfo6JF+N7HUExVs5gUFgkgVGHDEog9O+qtouh7IuJWk8TBQ+KwXEgRiXbatSj7EbTu3/yYnHuzh3XExbfF6wQ==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.0.5.tgz",
+      "integrity": "sha512-uG2dR5AObLuUrWWjj/de5XxNHCVi+Ehths0DSRcLjHJdgw1TSejwoZZ5na6gVrl3znNjRdBRy5Br5UlhaIU3Ww==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",
@@ -3570,10 +3569,24 @@
         "firebase-functions": "lib/bin/firebase-functions.js"
       },
       "engines": {
-        "node": ">=14.10.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0"
+        "@apollo/server": "^5.2.0",
+        "@as-integrations/express4": "^1.1.2",
+        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0",
+        "graphql": "^16.12.0"
+      },
+      "peerDependenciesMeta": {
+        "@apollo/server": {
+          "optional": true
+        },
+        "@as-integrations/express4": {
+          "optional": true
+        },
+        "graphql": {
+          "optional": true
+        }
       }
     },
     "node_modules/firebase-functions-test": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -24,8 +24,7 @@
     "@google-cloud/vertexai": "^1.10.0",
     "@google/genai": "^1.41.0",
     "firebase-admin": "^13.6.1",
-    "firebase-functions": "^6.6.0",
-    "uuid": "^11.1.0"
+    "firebase-functions": "^7.0.5"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/functions/src/backupFacilityData.ts
+++ b/functions/src/backupFacilityData.ts
@@ -11,7 +11,7 @@
 
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import * as admin from 'firebase-admin';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 
 interface BackupRequest {
   facilityId: string;
@@ -119,7 +119,7 @@ export const backupFacilityData = onCall<BackupRequest, Promise<BackupResponse>>
       const leaveRequests = leaveRequestsSnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
 
       // 6. バックアップオブジェクトを作成
-      const backupId = uuidv4();
+      const backupId = randomUUID();
       const timestamp = new Date().toISOString();
 
       const backupData = {

--- a/functions/src/scheduledBackup.ts
+++ b/functions/src/scheduledBackup.ts
@@ -11,7 +11,7 @@
 
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import * as admin from 'firebase-admin';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 
 /**
  * 毎日午前2時（JST）に全施設のバックアップを実行
@@ -87,7 +87,7 @@ export const scheduledBackup = onSchedule(
             .get();
           const leaveRequests = leaveRequestsSnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
 
-          const backupId = uuidv4();
+          const backupId = randomUUID();
           const timestamp = new Date().toISOString();
 
           const backupData = {


### PR DESCRIPTION
## Summary
- firebase-functions 6.6.0→7.0.5 メジャー更新
- uuid依存を削除し、Node.js組み込みの`crypto.randomUUID()`に置換
  - uuid v12+はESM-onlyでCommonJS（functions/tsconfig.json）非対応のため
  - `crypto.randomUUID()`はNode 19+で利用可能（プロジェクトはNode 20）

## Test plan
- [x] `npx tsc --noEmit` 型チェック通過
- [x] Jest 17スイート、350テスト全パス
- [ ] CI/CD パイプライン通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)