### PR TITLE
fix: solver-functions predeployコマンドをPOSIX互換に修正

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -29,7 +29,7 @@
         "tests"
       ],
       "predeploy": [
-        "command -v python3.12 >/dev/null 2>&1 && cd \"$RESOURCE_DIR\" && python3.12 -m venv venv && venv/bin/pip install -r requirements.txt || echo 'SKIP: python3.12 not found (solver-functions predeploy skipped)'"
+        "cd \"$RESOURCE_DIR\" && python3.12 -m venv venv && venv/bin/pip install -r requirements.txt"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- CI環境（Ubuntu/dash）で solver-functions の predeploy コマンドがシンタックスエラーを起こし、Python Cloud Functions がデプロイされない問題を修正
- `command -v python3.12 ... || echo '...()'` の括弧が dash シェルで解析エラー → シンプルな POSIX 互換コマンドに変更
- CIワークフロー（`.github/workflows/firebase-hosting-merge.yml` lines 381-385）で venv 作成・依存インストール済みのため、`command -v` チェックは不要

## Changes
- `firebase.json` line 32: predeploy コマンドを簡素化

## Root Cause
PR #65 で導入された `command -v python3.12 >/dev/null 2>&1 && ... || echo 'SKIP: python3.12 not found (solver-functions predeploy skipped)'` の `echo` 内の括弧 `()` が、CI環境の `/bin/sh`（dash）でサブシェル構文として解析されシンタックスエラー。

## Test plan
- [ ] CI/CD パイプライン通過確認
- [ ] Firebase デプロイジョブのログで solver-functions デプロイ成功確認
- [ ] `curl -X POST https://asia-northeast1-ai-care-shift-scheduler.cloudfunctions.net/solverUnifiedGenerate` で 200 応答確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the build configuration for solver-functions deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->