### PR TITLE
feat: Solver Level 2 事前検証警告

### DIFF
--- a/functions/src/shift-generation.ts
+++ b/functions/src/shift-generation.ts
@@ -105,7 +105,7 @@ export const generateShift = onRequest(
       // 統合Solver（CP-SAT）で全スタッフ数のシフトを一括生成
       console.log(`📊 統合Solver生成（${staffList.length}名）`);
 
-      const schedules = await generateShiftsWithUnifiedSolver(
+      const { schedule: schedules, warnings: solverWarnings } = await generateShiftsWithUnifiedSolver(
         staffList,
         requirements as ShiftRequirement,
         leaveRequests || {},
@@ -135,11 +135,17 @@ export const generateShift = onRequest(
         evaluation = createDefaultEvaluation();
       }
 
+      // Solver事前検証警告を評価結果に添付
+      if (solverWarnings.length > 0) {
+        evaluation.solverWarnings = solverWarnings;
+      }
+
       // 成功レスポンス（scheduleデータ + 評価データ）
       res.status(200).json({
         success: true,
         schedule: scheduleData.schedule,
         evaluation: evaluation,
+        solverWarnings,
         metadata: {
           generatedAt: new Date().toISOString(),
           model: 'cp-sat-unified',

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -87,6 +87,22 @@ export interface StaffSchedule {
 }
 
 // ============================================
+// Solver警告 型定義
+// ============================================
+
+/**
+ * Solver事前検証警告: 制約スキップの検知結果
+ */
+export interface SolverWarning {
+  date: string;
+  shiftType: string;
+  constraintType: 'staffShortage' | 'qualificationMissing';
+  requiredCount: number;
+  availableCount: number;
+  detail: string;
+}
+
+// ============================================
 // 評価・フィードバック機能 型定義
 // ============================================
 
@@ -163,6 +179,7 @@ export interface EvaluationResult {
     infeasibilityReasons: string[];
     suggestions: string[];
   };
+  solverWarnings?: SolverWarning[]; // Solver事前検証警告
   rootCauseAnalysis?: {           // Phase 55: 根本原因分析結果
     primaryCause: {
       category: string;

--- a/solver-functions/solver/service.py
+++ b/solver-functions/solver/service.py
@@ -101,6 +101,7 @@ class UnifiedSolverService:
         try:
             builder = UnifiedModelBuilder(staff_list, requirements, leave_requests)
             model = builder.build()
+            pre_warnings = builder.warnings
 
             solver = cp_model.CpSolver()
             solver.parameters.max_time_in_seconds = 30.0
@@ -126,6 +127,7 @@ class UnifiedSolverService:
                         "numConstraints": model.Proto().constraints.__len__(),
                         "objectiveValue": int(solver.ObjectiveValue()),
                     },
+                    "warnings": pre_warnings,
                 }
             else:
                 return {
@@ -136,6 +138,7 @@ class UnifiedSolverService:
                         "status": status_name,
                         "solveTimeMs": solve_time_ms,
                     },
+                    "warnings": pre_warnings,
                 }
 
         except Exception as e:
@@ -144,4 +147,5 @@ class UnifiedSolverService:
                 "error": str(e),
                 "errorType": "INTERNAL_ERROR",
                 "details": {},
+                "warnings": [],
             }

--- a/solver-functions/solver/types.py
+++ b/solver-functions/solver/types.py
@@ -118,10 +118,21 @@ class SolverStats(TypedDict):
     objectiveValue: int
 
 
+class SolverWarningDict(TypedDict):
+    """制約スキップ警告: 配置可能スタッフ不足で制約適用不可"""
+    date: str           # "2026-03-05"
+    shiftType: str      # "日勤"
+    constraintType: str # "staffShortage" | "qualificationMissing"
+    requiredCount: int
+    availableCount: int
+    detail: str         # 人間向け説明
+
+
 class SolverResponse(TypedDict):
     success: bool
     schedule: list[StaffScheduleDict]
     solverStats: SolverStats
+    warnings: list[SolverWarningDict]
 
 
 class SolverErrorResponse(TypedDict):


### PR DESCRIPTION
## Summary

- CP-SAT Solverの `_add_staffing` / `_add_qualification` で制約がサイレントスキップされる問題を解消
- 配置可能スタッフ不足時にSolverが警告（`SolverWarning`）を事前検知し返却
- 警告はevaluation結果とAPIレスポンスの両方に添付され、Level 2違反の原因が明確に

## Changes

| ファイル | 変更 |
|---------|------|
| `solver-functions/solver/types.py` | `SolverWarningDict` 型追加 |
| `solver-functions/solver/unified_builder.py` | 警告収集ロジック（`staffShortage` / `qualificationMissing`） |
| `solver-functions/solver/service.py` | レスポンスに `warnings` フィールド追加 |
| `functions/src/types.ts` | `SolverWarning` interface追加、`EvaluationResult` 拡張 |
| `functions/src/solver-client.ts` | `UnifiedSolverResult` 型追加、戻り値変更 |
| `functions/src/shift-generation.ts` | 警告をevaluation/レスポンスに添付 |
| `solver-functions/tests/test_unified_builder.py` | `TestPreValidationWarnings` 5テスト追加 |

## Test plan

- [x] Python型チェック OK
- [x] TypeScript型チェック (`tsc --noEmit`) OK
- [x] Python全65テスト合格（新規5テスト + 既存60テスト影響なし）
- [ ] CI/CD パイプライン通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added solver warnings to shift generation results, providing pre-validation alerts for staffing shortages and qualification mismatches alongside scheduling outcomes.

* **Tests**
  * Added comprehensive test coverage for solver warning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->