### PR TITLE
feat: Solver警告フロントエンド表示

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,8 +1,8 @@
 # ハンドオフメモ - 最新状態
 
-**更新日**: 2026-02-18（PR #79 Solver Level 2 事前検証警告 マージ完了）
+**更新日**: 2026-02-18（Solver警告フロントエンド表示 PR作成中）
 **フェーズ**: LLM→Solver完全移行 **本番稼働中** ✅
-**最新作業**: PR #79マージ（Solver Level 2 事前検証警告機能）
+**最新作業**: Solver警告フロントエンド表示（PR #79のBackend実装に対するUI対応）
 
 ---
 
@@ -41,7 +41,15 @@
 
 ## 直近の変更（最新5件）
 
-1. **PR #79マージ** (2026-02-18): Solver Level 2 事前検証警告
+1. **PR #80（作成中）** (2026-02-18): Solver警告フロントエンド表示
+   - PR #79のBackend `SolverWarning` に対するフロントエンドUI対応
+   - `SolverWarningsSection` コンポーネント新設（constraintType別グループ化、日付チップ、折りたたみ）
+   - フロントエンド型定義追加（`SolverWarning`, `EvaluationResult.solverWarnings`, `GenerateShiftResponse.solverWarnings`）
+   - Backend `GenerateShiftResponse` にも `solverWarnings` フィールド追加（型安全性修正）
+   - `formatDateWithDay` 重複解消（ファイルトップレベルに共通化）
+   - 変更ファイル: `types.ts`, `EvaluationPanel.tsx`, `shiftGenerationService.ts`, `functions/src/types.ts`
+
+2. **PR #79マージ** (2026-02-18): Solver Level 2 事前検証警告
    - コミット: `8427a4b` - feat: Solver Level 2 事前検証警告 - 制約スキップを事前検知し警告返却
    - CP-SAT Solverの `_add_staffing` / `_add_qualification` でサイレントスキップを解消
    - 配置可能スタッフ不足時に `SolverWarning`（`staffShortage` / `qualificationMissing`）を事前検知して返却
@@ -61,8 +69,7 @@
 
 4. **PR #77** (2026-02-16): ReportPageバンドルサイズ最適化（90%削減）
 
-5. **PR #73** (2026-02-16): Solver relative_gap_limit緩和で4シフト対応高速化
-   - 15名×4シフト: 30s FEASIBLE → 5.8s OPTIMAL
+5. ~~PR #73 (2026-02-16): Solver relative_gap_limit緩和で4シフト対応高速化~~
 
 ---
 
@@ -74,6 +81,7 @@
 | **CP-SAT Solver** | ✅ 本番稼働中 | 決定的スケジュール生成、100名対応 |
 | **評価システム** | ✅ 4段階評価 | Level 1-4対応、動的制約生成 |
 | **事前検証警告** | ✅ PR #79マージ済み | staffShortage/qualificationMissing警告 |
+| **警告UI表示** | 🔧 PR作成中 | EvaluationPanelにSolverWarningsSection追加 |
 
 ---
 
@@ -167,35 +175,33 @@
 
 - [x] `git status` がclean（未コミット変更なし）✅
 - [x] `git log` で最新コミット確認（PR #79 Solver Level 2 事前検証警告 マージ済み）✅
-- [ ] CI/CD ジョブ確認（PR #79 main push → Lighthouse/CI/CD in_progress）⚠️
+- [x] CI/CD ジョブ確認（PR #79 main push → CI/CD Pipeline + Lighthouse CI 全成功）✅
 - [x] LLM→Solver完全移行 本番稼働確認（solverUnifiedGenerate稼働中）✅
 - [x] テスト全通過確認（Frontend 161, Backend 230, Solver 65）✅
 
 ---
 
-## 本セッション作業内容（2026-02-18セッション：Solver Level 2 事前検証警告 PR #79）
+## 本セッション作業内容（2026-02-18セッション：Solver警告フロントエンド表示）
 
 ### 実装内容
-- CP-SAT Solverの `_add_staffing` / `_add_qualification` でのサイレントスキップ問題を解消
-- `SolverWarning` 型（`staffShortage` / `qualificationMissing`）を新設
-- 警告はevaluation結果とAPIレスポンス両方に添付。Level 2違反の原因が明確化
-- Pythonテスト: `TestPreValidationWarnings` 5テスト追加（65/65全通過）
+- PR #79のBackend `SolverWarning` に対するフロントエンドUI対応
+- `SolverWarningsSection` コンポーネント新設（constraintType別グループ化、日付チップ、5件超折りたたみ）
+- フロントエンド型定義追加（`SolverWarning`, `EvaluationResult.solverWarnings`, `GenerateShiftResponse.solverWarnings`）
+- Backend `GenerateShiftResponse` の型安全性修正（`solverWarnings` フィールド追加）
+- コードレビュー指摘対応: `formatDateWithDay` 重複解消、React keyの一意化
 
 ### 変更ファイル
 | ファイル | 変更内容 |
 |---------|---------|
-| `solver-functions/solver/types.py` | `SolverWarningDict` 型追加 |
-| `solver-functions/solver/unified_builder.py` | 警告収集ロジック追加 |
-| `solver-functions/solver/service.py` | レスポンスに `warnings` フィールド追加 |
-| `functions/src/types.ts` | `SolverWarning` interface追加、`EvaluationResult` 拡張 |
-| `functions/src/solver-client.ts` | `UnifiedSolverResult` 型追加、戻り値変更 |
-| `functions/src/shift-generation.ts` | 警告をevaluation/レスポンスに添付 |
-| `solver-functions/tests/test_unified_builder.py` | `TestPreValidationWarnings` 5テスト追加 |
+| `types.ts` (root) | `SolverWarning` interface追加、`EvaluationResult`/`GenerateShiftResponse` 拡張 |
+| `src/components/EvaluationPanel.tsx` | `SolverWarningsSection` コンポーネント追加、`formatDateWithDay` 共通化 |
+| `services/shiftGenerationService.ts` | `SolverWarning` import、ログ出力追加 |
+| `functions/src/types.ts` | `GenerateShiftResponse` に `solverWarnings` フィールド追加 |
 
 ### 成果
-- **品質**: Level 2違反の原因がAPIレスポンスで可視化
-- **テスト**: Solver 60/60 → 65/65
-- **マージ**: PR #79 スカッシュマージ完了（8427a4b）
+- **品質**: Level 2違反の根本原因がUIで可視化（配置可能スタッフ不足 / 資格要件未充足）
+- **型安全性**: FE/BE両方の `GenerateShiftResponse` で `solverWarnings` 型定義済み
+- **検証**: Frontend/Backend型チェック + ビルド全通過
 
 ---
 

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -244,6 +244,7 @@ export interface GenerateShiftResponse {
     model: string;
     tokensUsed: number;
   };
+  solverWarnings?: SolverWarning[];  // Solver事前検証警告
   error?: string;
   parseError?: unknown;  // デバッグ用
 }

--- a/services/shiftGenerationService.ts
+++ b/services/shiftGenerationService.ts
@@ -5,6 +5,7 @@ import type {
   LeaveRequest,
   GenerateShiftResponse,
   EvaluationResult,
+  SolverWarning,
 } from '../types';
 
 /**
@@ -125,6 +126,13 @@ export const generateShiftSchedule = async (
         fulfillmentRate: result.evaluation.fulfillmentRate,
         violationCount: result.evaluation.constraintViolations?.length || 0,
         recommendationCount: result.evaluation.recommendations?.length || 0,
+      });
+    }
+
+    if (result.solverWarnings?.length) {
+      console.log('⚠️ Solver事前検証警告:', {
+        count: result.solverWarnings.length,
+        types: [...new Set(result.solverWarnings.map((w: SolverWarning) => w.constraintType))],
       });
     }
 

--- a/types.ts
+++ b/types.ts
@@ -503,6 +503,22 @@ export interface SimulationResult {
   risks: string[];                  // リスク要因
 }
 
+// ============================================
+// Solver警告 型定義
+// ============================================
+
+/**
+ * Solver事前検証警告: 制約スキップの検知結果
+ */
+export interface SolverWarning {
+  date: string;
+  shiftType: string;
+  constraintType: 'staffShortage' | 'qualificationMissing';
+  requiredCount: number;
+  availableCount: number;
+  detail: string;
+}
+
 /**
  * 評価結果
  */
@@ -515,6 +531,7 @@ export interface EvaluationResult {
   generatedAt: Timestamp;
   aiComment?: string;             // AI総合コメント（200文字以内）
   positiveSummary?: string;       // Phase 53: ポジティブサマリー
+  solverWarnings?: SolverWarning[];  // Solver事前検証警告
   rootCauseAnalysis?: {           // Phase 55: 根本原因分析結果
     primaryCause: {
       category: string;
@@ -589,6 +606,7 @@ export interface GenerateShiftResponse {
     model: string;
     tokensUsed: number;
   };
+  solverWarnings?: SolverWarning[];  // Solver事前検証警告
   error?: string;
   parseError?: unknown;  // デバッグ用
 }


### PR DESCRIPTION
## Summary

- PR #79のBackend `SolverWarning` に対するフロントエンドUI対応
- `EvaluationPanel` に `SolverWarningsSection` コンポーネントを新設し、Level 2違反の根本原因をUIで可視化
- Backend `GenerateShiftResponse` の型安全性修正（`solverWarnings` フィールド追加）

### 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `types.ts` (root) | `SolverWarning` interface追加、`EvaluationResult`/`GenerateShiftResponse` 拡張 |
| `src/components/EvaluationPanel.tsx` | `SolverWarningsSection` コンポーネント追加（+190行）、`formatDateWithDay` 重複解消 |
| `services/shiftGenerationService.ts` | `SolverWarning` import、ログ出力追加 |
| `functions/src/types.ts` | `GenerateShiftResponse` に `solverWarnings` 追加（型安全性修正） |

### UI設計

- `constraintType` でグループ化: `staffShortage`(橙色) / `qualificationMissing`(紫色)
- グループ内でシフト種別ごとにサブグループ化、日付チップ表示
- 5グループ超は折りたたみ（「+N件を表示」ボタン）

## Test plan

- [x] Frontend TypeScript型チェック通過 (`npx tsc --noEmit`)
- [x] Backend TypeScript型チェック通過 (`cd functions && npx tsc --noEmit`)
- [x] ビルド通過 (`npm run build`)
- [ ] CI/CD Pipeline通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added solver warnings to shift generation results, displaying pre-check alerts for staffing issues (staff shortages, qualification gaps) grouped by constraint type and shift date with improved date formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->