### PR TITLE
feat: 希望休重複の事前バリデーション - 資格要件競合をシフト生成前に検出

### DIFF
--- a/src/services/__tests__/leaveConflictValidator.test.ts
+++ b/src/services/__tests__/leaveConflictValidator.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect } from 'vitest';
+import {
+  detectLeaveQualificationConflicts,
+} from '../leaveConflictValidator';
+import {
+  Qualification,
+  Role,
+  TimeSlotPreference,
+  LeaveType,
+  Staff,
+  LeaveRequest,
+  ShiftRequirement,
+} from '../../../types';
+
+// ── テスト用ファクトリ ─────────────────────────────────────
+
+function makeStaff(
+  id: string,
+  name: string,
+  qualifications: Qualification[] = []
+): Staff {
+  return {
+    id,
+    name,
+    role: Role.Nurse,
+    qualifications,
+    weeklyWorkCount: { hope: 5, must: 5 },
+    maxConsecutiveWorkDays: 5,
+    availableWeekdays: [0, 1, 2, 3, 4, 5, 6],
+    unavailableDates: [],
+    timeSlotPreference: TimeSlotPreference.Any,
+    isNightShiftOnly: false,
+  };
+}
+
+function makeRequirements(
+  targetMonth: string,
+  shifts: Record<string, { qual: Qualification; count: number }[]>
+): ShiftRequirement {
+  return {
+    targetMonth,
+    timeSlots: Object.keys(shifts).map((name) => ({
+      name,
+      start: '09:00',
+      end: '18:00',
+      restHours: 1,
+    })),
+    requirements: Object.fromEntries(
+      Object.entries(shifts).map(([name, quals]) => [
+        name,
+        {
+          totalStaff: 3,
+          requiredQualifications: quals.map((q) => ({
+            qualification: q.qual,
+            count: q.count,
+          })),
+          requiredRoles: [],
+        },
+      ])
+    ),
+  };
+}
+
+// ── テストスイート ────────────────────────────────────────
+
+describe('detectLeaveQualificationConflicts', () => {
+  // ───────────── 基本ケース ─────────────
+  describe('基本ケース', () => {
+    it('希望休がなければ警告は発生しない', () => {
+      const staffList: Staff[] = [
+        makeStaff('s1', '看護師A', [Qualification.RegisteredNurse]),
+        makeStaff('s2', '看護師B', [Qualification.RegisteredNurse]),
+        makeStaff('s3', '介護士A', []),
+      ];
+      const leaveRequests: LeaveRequest = {};
+      const requirements = makeRequirements('2026-03', {
+        日勤: [{ qual: Qualification.RegisteredNurse, count: 1 }],
+      });
+
+      const result = detectLeaveQualificationConflicts(
+        staffList,
+        leaveRequests,
+        requirements
+      );
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('資格要件のないシフトで希望休が集中しても警告なし', () => {
+      const staffList: Staff[] = [
+        makeStaff('s1', '介護士A', []),
+        makeStaff('s2', '介護士B', []),
+      ];
+      const leaveRequests: LeaveRequest = {
+        s1: { '2026-03-10': LeaveType.Hope },
+        s2: { '2026-03-10': LeaveType.Hope },
+      };
+      const requirements = makeRequirements('2026-03', {
+        日勤: [],
+      });
+
+      const result = detectLeaveQualificationConflicts(
+        staffList,
+        leaveRequests,
+        requirements
+      );
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  // ───────────── 看護師2名が同日に希望休（主要シナリオ） ─────────────
+  describe('看護師が同日希望休で資格不足', () => {
+    it('看護師2名が同日希望休 → qualificationMissing警告が発生する', () => {
+      const staffList: Staff[] = [
+        makeStaff('s1', '看護師A', [Qualification.RegisteredNurse]),
+        makeStaff('s2', '看護師B', [Qualification.RegisteredNurse]),
+        makeStaff('s3', '介護士A', []),
+      ];
+      const leaveRequests: LeaveRequest = {
+        s1: { '2026-03-10': LeaveType.Hope },
+        s2: { '2026-03-10': LeaveType.Hope },
+      };
+      const requirements = makeRequirements('2026-03', {
+        日勤: [{ qual: Qualification.RegisteredNurse, count: 1 }],
+      });
+
+      const result = detectLeaveQualificationConflicts(
+        staffList,
+        leaveRequests,
+        requirements
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].date).toBe('2026-03-10');
+      expect(result[0].qualification).toBe(Qualification.RegisteredNurse);
+      expect(result[0].requiredCount).toBe(1);
+      expect(result[0].availableCount).toBe(0);
+      expect(result[0].affectedStaff).toContain('看護師A');
+      expect(result[0].affectedStaff).toContain('看護師B');
+    });
+
+    it('看護師1名のみ希望休で1名必要 → 0名配置可能 → 警告', () => {
+      const staffList: Staff[] = [
+        makeStaff('s1', '看護師A', [Qualification.RegisteredNurse]),
+        makeStaff('s2', '介護士A', []),
+      ];
+      const leaveRequests: LeaveRequest = {
+        s1: { '2026-03-15': LeaveType.PaidLeave },
+      };
+      const requirements = makeRequirements('2026-03', {
+        日勤: [{ qual: Qualification.RegisteredNurse, count: 1 }],
+      });
+
+      const result = detectLeaveQualificationConflicts(
+        staffList,
+        leaveRequests,
+        requirements
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].availableCount).toBe(0);
+      expect(result[0].affectedStaff).toEqual(['看護師A']);
+    });
+
+    it('看護師1名が希望休でも別の看護師が出勤可能なら警告なし', () => {
+      const staffList: Staff[] = [
+        makeStaff('s1', '看護師A', [Qualification.RegisteredNurse]),
+        makeStaff('s2', '看護師B', [Qualification.RegisteredNurse]),
+        makeStaff('s3', '介護士A', []),
+      ];
+      const leaveRequests: LeaveRequest = {
+        s1: { '2026-03-10': LeaveType.Hope },
+      };
+      const requirements = makeRequirements('2026-03', {
+        日勤: [{ qual: Qualification.RegisteredNurse, count: 1 }],
+      });
+
+      const result = detectLeaveQualificationConflicts(
+        staffList,
+        leaveRequests,
+        requirements
+      );
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  // ───────────── 複数シフト・複数資格 ─────────────
+  describe('複数シフト・複数資格', () => {
+    it('日勤と夜勤それぞれで看護師1名必要 → 合計2名必要 → 1名不足で警告', () => {
+      const staffList: Staff[] = [
+        makeStaff('s1', '看護師A', [Qualification.RegisteredNurse]),
+        makeStaff('s2', '看護師B', [Qualification.RegisteredNurse]),
+        makeStaff('s3', '介護士A', []),
+      ];
+      const leaveRequests: LeaveRequest = {
+        s1: { '2026-03-10': LeaveType.Hope },
+      };
+      const requirements = makeRequirements('2026-03', {
+        日勤: [{ qual: Qualification.RegisteredNurse, count: 1 }],
+        夜勤: [{ qual: Qualification.RegisteredNurse, count: 1 }],
+      });
+
+      const result = detectLeaveQualificationConflicts(
+        staffList,
+        leaveRequests,
+        requirements
+      );
+
+      // 合計2名必要で1名配置可能 → 警告
+      expect(result).toHaveLength(1);
+      expect(result[0].requiredCount).toBe(2);
+      expect(result[0].availableCount).toBe(1);
+    });
+
+    it('複数の資格要件があるとき、不足する資格のみ警告が出る', () => {
+      const staffList: Staff[] = [
+        makeStaff('s1', '看護師A', [Qualification.RegisteredNurse]),
+        makeStaff('s2', '理学療法士A', [Qualification.PhysicalTherapist]),
+        makeStaff('s3', '介護士A', []),
+      ];
+      const leaveRequests: LeaveRequest = {
+        s1: { '2026-03-10': LeaveType.Hope },
+      };
+      const requirements = makeRequirements('2026-03', {
+        日勤: [
+          { qual: Qualification.RegisteredNurse, count: 1 },
+          { qual: Qualification.PhysicalTherapist, count: 1 },
+        ],
+      });
+
+      const result = detectLeaveQualificationConflicts(
+        staffList,
+        leaveRequests,
+        requirements
+      );
+
+      // 看護師のみ不足、理学療法士は問題なし
+      expect(result).toHaveLength(1);
+      expect(result[0].qualification).toBe(Qualification.RegisteredNurse);
+    });
+  });
+
+  // ───────────── 境界値 ─────────────
+  describe('境界値', () => {
+    it('対象月外の希望休は無視される', () => {
+      const staffList: Staff[] = [
+        makeStaff('s1', '看護師A', [Qualification.RegisteredNurse]),
+      ];
+      const leaveRequests: LeaveRequest = {
+        s1: { '2026-04-01': LeaveType.Hope }, // 4月（対象は3月）
+      };
+      const requirements = makeRequirements('2026-03', {
+        日勤: [{ qual: Qualification.RegisteredNurse, count: 1 }],
+      });
+
+      const result = detectLeaveQualificationConflicts(
+        staffList,
+        leaveRequests,
+        requirements
+      );
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('スタッフリストが空の場合、警告なし', () => {
+      const staffList: Staff[] = [];
+      const leaveRequests: LeaveRequest = {};
+      const requirements = makeRequirements('2026-03', {
+        日勤: [{ qual: Qualification.RegisteredNurse, count: 1 }],
+      });
+
+      const result = detectLeaveQualificationConflicts(
+        staffList,
+        leaveRequests,
+        requirements
+      );
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('有給休暇・研修による希望休も資格不足を引き起こす', () => {
+      const staffList: Staff[] = [
+        makeStaff('s1', '看護師A', [Qualification.RegisteredNurse]),
+      ];
+      const leaveRequests: LeaveRequest = {
+        s1: { '2026-03-05': LeaveType.Training },
+      };
+      const requirements = makeRequirements('2026-03', {
+        日勤: [{ qual: Qualification.RegisteredNurse, count: 1 }],
+      });
+
+      const result = detectLeaveQualificationConflicts(
+        staffList,
+        leaveRequests,
+        requirements
+      );
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('複数日で重複するとき、各日に独立した警告が出る', () => {
+      const staffList: Staff[] = [
+        makeStaff('s1', '看護師A', [Qualification.RegisteredNurse]),
+      ];
+      const leaveRequests: LeaveRequest = {
+        s1: {
+          '2026-03-05': LeaveType.Hope,
+          '2026-03-10': LeaveType.Hope,
+        },
+      };
+      const requirements = makeRequirements('2026-03', {
+        日勤: [{ qual: Qualification.RegisteredNurse, count: 1 }],
+      });
+
+      const result = detectLeaveQualificationConflicts(
+        staffList,
+        leaveRequests,
+        requirements
+      );
+
+      expect(result).toHaveLength(2);
+      const dates = result.map((w) => w.date).sort();
+      expect(dates).toEqual(['2026-03-05', '2026-03-10']);
+    });
+  });
+});

--- a/src/services/leaveConflictValidator.ts
+++ b/src/services/leaveConflictValidator.ts
@@ -1,0 +1,74 @@
+import { Staff, LeaveRequest, ShiftRequirement, Qualification } from '../../types';
+
+/**
+ * 希望休と資格要件の競合を表す警告
+ */
+export interface LeaveConflictWarning {
+  /** 問題が発生する日付（YYYY-MM-DD） */
+  date: string;
+  /** 不足する資格 */
+  qualification: Qualification;
+  /** 全シフト合計で必要な有資格者数 */
+  requiredCount: number;
+  /** 希望休を除いた配置可能な有資格者数 */
+  availableCount: number;
+  /** 希望休を申請した有資格者の名前リスト */
+  affectedStaff: string[];
+}
+
+/**
+ * 希望休が資格要件を満たせなくなる日付を事前に検出する
+ *
+ * 各日・各資格について「全シフト合計で必要な有資格者数 > 希望休を除いた有資格者数」
+ * となる場合に警告を返す。
+ *
+ * @param staffList スタッフリスト（資格情報を含む）
+ * @param leaveRequests 希望休データ { staffId: { date: LeaveType } }
+ * @param requirements シフト要件（資格要件を含む）
+ * @returns 資格不足を引き起こす希望休の警告リスト
+ */
+export function detectLeaveQualificationConflicts(
+  staffList: Staff[],
+  leaveRequests: LeaveRequest,
+  requirements: ShiftRequirement
+): LeaveConflictWarning[] {
+  // 全シフトの資格ごとに必要人数を合算
+  const qualRequirements = new Map<Qualification, number>();
+  for (const dailyReq of Object.values(requirements.requirements)) {
+    for (const { qualification, count } of dailyReq.requiredQualifications ?? []) {
+      qualRequirements.set(qualification, (qualRequirements.get(qualification) ?? 0) + count);
+    }
+  }
+
+  if (qualRequirements.size === 0) return [];
+
+  const warnings: LeaveConflictWarning[] = [];
+  const [year, month] = requirements.targetMonth.split('-').map(Number);
+  const daysInMonth = new Date(year, month, 0).getDate();
+
+  for (let day = 1; day <= daysInMonth; day++) {
+    const date = `${requirements.targetMonth}-${String(day).padStart(2, '0')}`;
+
+    for (const [qualification, requiredCount] of qualRequirements) {
+      const qualifiedStaff = staffList.filter((s) =>
+        s.qualifications?.includes(qualification)
+      );
+      const onLeave = qualifiedStaff.filter((s) => leaveRequests[s.id]?.[date]);
+      const availableCount = qualifiedStaff.length - onLeave.length;
+
+      // 有資格者が最初から不足している場合は別問題（leave conflictではない）
+      // leave requestsが原因で不足するケースのみ警告する
+      if (qualifiedStaff.length >= requiredCount && availableCount < requiredCount) {
+        warnings.push({
+          date,
+          qualification,
+          requiredCount,
+          availableCount,
+          affectedStaff: onLeave.map((s) => s.name),
+        });
+      }
+    }
+  }
+
+  return warnings;
+}


### PR DESCRIPTION
## Summary

- 有資格者（看護師等）が同日に希望休を申請した場合、シフト生成前の診断フェーズで Level 2 違反を事前警告する機能を追加
- `detectLeaveQualificationConflicts()` 純関数で「休暇申請が原因で資格要件を満たせなくなる日付」を検出
- 既存の `DiagnosisPanel`（`severity: 'high'` / 🔴表示）に統合済み、UIの追加変更なし

## 変更ファイル

| ファイル | 変更種別 | 概要 |
|---------|---------|------|
| `src/services/leaveConflictValidator.ts` | 新規 | 純関数 `detectLeaveQualificationConflicts()` |
| `src/services/__tests__/leaveConflictValidator.test.ts` | 新規 | TDDテスト 11件 |
| `src/services/diagnosisService.ts` | 変更 | step 5として統合 |

## ロジック

```
全シフト合計の必要資格者数 vs 希望休考慮後の配置可能数 を日付ごとに比較
├─ 有資格者が休暇申請前から不足している → 対象外（別の構造問題）
└─ 休暇申請によって必要数を下回る → ⚠️ 警告（Level 2違反が発生予定）
```

## Test plan

- [x] 11件の新規ユニットテスト（基本ケース・主要シナリオ・境界値）
- [x] 既存フロントエンドテスト 161件 → 172件全通過
- [x] TypeScript型チェック: エラーなし
- [ ] DiagnosisPanelで実際に警告が表示されることを画面確認（CI後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated leave qualification conflict detection into the scheduling system to identify when approved leave requests would result in insufficient qualified staff available to meet shift requirements, helping prevent coverage gaps.

* **Tests**
  * Added comprehensive test suite covering various leave and qualification scenarios to ensure conflict detection accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->