### PR TITLE
feat: Staff/Facility型に勤務形態区分・週所定労働時間を追加

### DIFF
--- a/components/StaffSettings.tsx
+++ b/components/StaffSettings.tsx
@@ -1,8 +1,8 @@
 
 import React, { useState, useEffect, useRef } from 'react';
-import type { Staff } from '../types';
+import type { Staff, EmploymentType } from '../types';
 import { Role, Qualification, TimeSlotPreference } from '../types';
-import { ROLES, QUALIFICATIONS, TIME_SLOT_PREFERENCES } from '../constants';
+import { ROLES, QUALIFICATIONS, TIME_SLOT_PREFERENCES, EMPLOYMENT_TYPES } from '../constants';
 import CalendarPicker from './CalendarPicker';
 
 interface StaffSettingsProps {
@@ -138,6 +138,39 @@ const StaffSettings: React.FC<StaffSettingsProps> = ({
                   ))}
                 </div>
               </div>
+              {/* Employment Type */}
+              <div>
+                <label className="block font-medium text-slate-600 mb-1">勤務形態区分</label>
+                <select
+                  value={staff.employmentType ?? 'A'}
+                  onChange={e => onStaffChange({ ...staff, employmentType: e.target.value as EmploymentType })}
+                  className="w-full p-2 pr-8 bg-white text-slate-800 border border-slate-300 rounded-md shadow-xs appearance-none bg-select-arrow bg-no-repeat bg-position-[center_right_0.75rem] focus:outline-hidden focus:ring-2 focus:ring-care-secondary focus:border-care-secondary"
+                >
+                  {(Object.entries(EMPLOYMENT_TYPES) as [EmploymentType, string][]).map(([key, label]) => (
+                    <option key={key} value={key}>{key}: {label}</option>
+                  ))}
+                </select>
+                <p className="mt-1 text-xs text-slate-400">行政提出用（標準様式第1号）に使用します</p>
+              </div>
+              {/* Weekly Contract Hours (non-constant staff only) */}
+              {(staff.employmentType === 'C' || staff.employmentType === 'D') && (
+                <div>
+                  <label className="block font-medium text-slate-600 mb-1">契約週時間（非常勤）</label>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="number"
+                      min={1}
+                      max={40}
+                      step={0.5}
+                      value={staff.weeklyContractHours ?? ''}
+                      onChange={e => onStaffChange({ ...staff, weeklyContractHours: Number(e.target.value) })}
+                      placeholder="例: 20"
+                      className="w-24 p-2 bg-white text-slate-800 border border-slate-300 rounded-md shadow-xs focus:outline-hidden focus:ring-2 focus:ring-care-secondary focus:border-care-secondary"
+                    />
+                    <span className="text-slate-500">時間/週（常勤換算計算に使用）</span>
+                  </div>
+                </div>
+              )}
               {/* isNightShiftOnly */}
               <div>
                 <label className="flex items-center space-x-2 font-medium text-slate-600 cursor-pointer">

--- a/constants.ts
+++ b/constants.ts
@@ -1,5 +1,5 @@
 
-import { Role, Qualification, TimeSlotPreference, ShiftTime, LeaveType, ShiftColor, ShiftTypeConfig } from './types';
+import { Role, Qualification, TimeSlotPreference, ShiftTime, LeaveType, ShiftColor, ShiftTypeConfig, EmploymentType } from './types';
 
 export const ROLES: Role[] = [
   Role.Admin,
@@ -123,6 +123,19 @@ export const DEFAULT_SHIFT_TYPES: ShiftTypeConfig[] = [
 
 // デフォルトシフトサイクル（ダブルクリック時のサイクル順序）
 export const DEFAULT_SHIFT_CYCLE: string[] = ['early', 'day', 'late', 'night', 'off', 'postnight'];
+
+// ==================== 勤務形態区分（Phase 25）====================
+
+// 勤務形態区分ラベルマップ（標準様式第1号）
+export const EMPLOYMENT_TYPES: Record<EmploymentType, string> = {
+  A: '常勤専従',
+  B: '常勤兼務',
+  C: '非常勤専従',
+  D: '非常勤兼務',
+};
+
+// 常勤の週所定労働時間デフォルト値（時間）
+export const DEFAULT_STANDARD_WEEKLY_HOURS = 40;
 
 // ==================== 休暇残高管理（Phase 39）====================
 

--- a/src/services/staffService.ts
+++ b/src/services/staffService.ts
@@ -70,6 +70,8 @@ export const StaffService = {
             unavailableDates: data.unavailableDates || [],
             timeSlotPreference: data.timeSlotPreference || {},
             isNightShiftOnly: data.nightShiftOnly ?? data.isNightShiftOnly ?? false,  // nightShiftOnly → isNightShiftOnly
+            employmentType: data.employmentType ?? 'A',  // 未設定時は常勤専従をデフォルト
+            ...(data.weeklyContractHours !== undefined && { weeklyContractHours: data.weeklyContractHours }),
             createdAt: data.createdAt,
             updatedAt: data.updatedAt,
           } as Staff;

--- a/src/utils/exportCSV.ts
+++ b/src/utils/exportCSV.ts
@@ -12,6 +12,7 @@
 
 import { unparse } from 'papaparse';
 import { Schedule, Staff, LeaveRequestDocument, StaffSchedule } from '../../types';
+import { EMPLOYMENT_TYPES } from '../../constants';
 
 /**
  * シフトデータをCSVエクスポート
@@ -85,21 +86,26 @@ export function exportStaffToCSV(
   }
 
   // データ行を作成
-  const rows = staffList.map((staff) => ({
-    'ID': staff.id,
-    '名前': staff.name,
-    '役職': staff.role,
-    '資格': staff.qualifications.join(', '),
-    '週間勤務数（希望）': staff.weeklyWorkCount.hope,
-    '週間勤務数（必須）': staff.weeklyWorkCount.must,
-    '最大連続勤務日数': staff.maxConsecutiveWorkDays,
-    '利用可能曜日': formatWeekdays(staff.availableWeekdays),
-    '利用不可日': staff.unavailableDates.join(', ') || 'なし',
-    '時間帯希望': staff.timeSlotPreference,
-    '夜勤専従': staff.isNightShiftOnly ? 'はい' : 'いいえ',
-    '作成日': formatTimestamp(staff.createdAt),
-    '更新日': formatTimestamp(staff.updatedAt),
-  }));
+  const rows = staffList.map((staff) => {
+    const empType = staff.employmentType ?? 'A';
+    return {
+      'ID': staff.id,
+      '名前': staff.name,
+      '役職': staff.role,
+      '資格': staff.qualifications.join(', '),
+      '勤務形態区分': `${empType}: ${EMPLOYMENT_TYPES[empType]}`,
+      '契約週時間': staff.weeklyContractHours ?? '-',
+      '週間勤務数（希望）': staff.weeklyWorkCount.hope,
+      '週間勤務数（必須）': staff.weeklyWorkCount.must,
+      '最大連続勤務日数': staff.maxConsecutiveWorkDays,
+      '利用可能曜日': formatWeekdays(staff.availableWeekdays),
+      '利用不可日': staff.unavailableDates.join(', ') || 'なし',
+      '時間帯希望': staff.timeSlotPreference,
+      '夜勤専従': staff.isNightShiftOnly ? 'はい' : 'いいえ',
+      '作成日': formatTimestamp(staff.createdAt),
+      '更新日': formatTimestamp(staff.updatedAt),
+    };
+  });
 
   // papaparseでCSV生成
   const csv = unparse(rows);

--- a/types.ts
+++ b/types.ts
@@ -49,6 +49,10 @@ export interface LeaveRequestDocument {
   updatedAt?: Timestamp;
 }
 
+// 勤務形態区分（標準様式第1号）
+// A=常勤専従, B=常勤兼務, C=非常勤専従, D=非常勤兼務
+export type EmploymentType = 'A' | 'B' | 'C' | 'D';
+
 export interface Staff {
   id: string;
   name: string;
@@ -60,6 +64,8 @@ export interface Staff {
   unavailableDates: string[]; // YYYY-MM-DD
   timeSlotPreference: TimeSlotPreference;
   isNightShiftOnly: boolean;
+  employmentType?: EmploymentType;   // 勤務形態区分（標準様式第1号）
+  weeklyContractHours?: number;      // 契約週時間（非常勤用、常勤換算計算に使用）
   createdAt?: Timestamp; // Firestore永続化時に使用
   updatedAt?: Timestamp; // Firestore永続化時に使用
 }
@@ -230,6 +236,7 @@ export interface Facility {
   createdAt: Timestamp;
   createdBy: string; // super-admin UID
   members: FacilityMember[]; // 非正規化（パフォーマンス最適化）
+  standardWeeklyHours?: number; // 常勤職員の週所定労働時間（常勤換算計算用、デフォルト40h）
 }
 
 // 施設メンバー（非正規化）


### PR DESCRIPTION
## Summary

- `EmploymentType` 型（A=常勤専従/B=常勤兼務/C=非常勤専従/D=非常勤兼務）を追加
- `Staff` に `employmentType?`・`weeklyContractHours?` フィールドを追加
- `Facility` に `standardWeeklyHours?` フィールドを追加（デフォルト40h）
- `StaffSettings.tsx` に勤務形態セレクターと非常勤向け契約週時間入力を追加
- `staffService.ts` にFirestore読込時のデフォルト値設定（後方互換性）
- スタッフCSVエクスポートに勤務形態区分・契約週時間列を追加

## 背景

Phase 25（予実管理・行政対応）の実装基盤。標準様式第1号（勤務形態一覧表）への出力と常勤換算計算（PR #B/#C）の前提となるデータモデル。

## Test plan

- [x] 型チェック: `npx tsc --noEmit` → エラーなし
- [x] フロントエンドテスト: 172テスト全通過
- [x] 後方互換性: 既存スタッフ（employmentType未設定）は 'A'（常勤専従）にデフォルト

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added employment type classification system for staff with four category options.
  * Added optional weekly contract hours tracking field (appears for specific employment types).
  * Enhanced CSV exports to include employment type and contract hours data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->