### PR TITLE
feat: Excelエクスポート機能を追加（Phase 25 #C）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "chart.js": "^4.5.1",
+        "exceljs": "^4.4.0",
         "firebase": "^12.9.0",
         "jspdf": "^4.1.0",
         "jspdf-autotable": "^5.0.7",
@@ -801,6 +802,47 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@fast-csv/format": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/@fast-csv/format/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
+    "node_modules/@fast-csv/parse": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+      "integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "node_modules/@fast-csv/parse/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
     },
     "node_modules/@fastify/busboy": {
       "version": "3.2.0",
@@ -3017,6 +3059,75 @@
         "node": ">= 14"
       }
     },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -3067,6 +3178,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -3086,6 +3203,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
     "node_modules/base64-arraybuffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
@@ -3100,7 +3223,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3127,6 +3249,15 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -3135,6 +3266,46 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/browserslist": {
@@ -3171,12 +3342,62 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "engines": {
+        "node": ">=0.2.0"
+      }
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -3242,6 +3463,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chart.js": {
@@ -3375,6 +3608,27 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3407,6 +3661,37 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/css-line-break": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
@@ -3422,6 +3707,12 @@
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.19",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
+      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -3507,6 +3798,45 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/duplexify": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
@@ -3542,9 +3872,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -3708,6 +4036,35 @@
         "node": ">=6"
       }
     },
+    "node_modules/exceljs": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
+      "integrity": "sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver": "^5.0.0",
+        "dayjs": "^1.8.34",
+        "fast-csv": "^4.3.1",
+        "jszip": "^3.10.1",
+        "readable-stream": "^3.6.0",
+        "saxes": "^5.0.1",
+        "tmp": "^0.2.0",
+        "unzipper": "^0.10.11",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/exceljs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3733,6 +4090,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/fast-csv": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+      "integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@fast-csv/parse": "4.3.6"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4007,6 +4377,18 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4020,6 +4402,22 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/function-bind": {
@@ -4112,6 +4510,27 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/google-gax": {
@@ -4308,7 +4727,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/happy-dom": {
@@ -4479,6 +4897,32 @@
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "license": "ISC"
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -4489,13 +4933,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/iobuffer": {
       "version": "5.4.0",
@@ -4524,6 +4977,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -4712,6 +5171,54 @@
         "jspdf": "^2 || ^3 || ^4"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -4751,6 +5258,57 @@
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -5020,6 +5578,12 @@
       "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
       "dev": true
     },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "license": "ISC"
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -5033,6 +5597,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -5044,7 +5638,19 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
@@ -5052,6 +5658,12 @@
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
       "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
@@ -5065,7 +5677,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isstring": {
@@ -5075,11 +5686,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
     },
     "node_modules/long": {
@@ -5251,6 +5880,39 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -5304,6 +5966,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
@@ -5330,9 +6001,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5365,6 +6034,15 @@
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
       "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
       "license": "MIT"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -5517,6 +6195,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/proto3-json-serializer": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
@@ -5656,9 +6340,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -5666,6 +6348,36 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/redent": {
@@ -5745,6 +6457,19 @@
         "node": ">= 0.8.15"
       }
     },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.52.5",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
@@ -5807,6 +6532,18 @@
       ],
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -5827,6 +6564,12 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
     "node_modules/siginfo": {
@@ -5908,9 +6651,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -5992,6 +6733,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/teeny-request": {
@@ -6132,6 +6889,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -6148,6 +6914,15 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -6195,6 +6970,54 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/unzipper/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -6230,9 +7053,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/utrie": {
       "version": "1.0.2",
@@ -6490,9 +7311,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.18.3",
@@ -6515,6 +7334,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -6612,6 +7437,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "chart.js": "^4.5.1",
+    "exceljs": "^4.4.0",
     "firebase": "^12.9.0",
     "jspdf": "^4.1.0",
     "jspdf-autotable": "^5.0.7",

--- a/src/utils/__tests__/exportExcel.test.ts
+++ b/src/utils/__tests__/exportExcel.test.ts
@@ -1,0 +1,232 @@
+/**
+ * exportExcel.test.ts
+ *
+ * Phase 25: Excel エクスポートのユニットテスト
+ * - 標準様式第1号の生成テスト
+ * - 予実2段書きの生成テスト
+ * - ファイル名生成テスト
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createStandardFormWorkbook,
+  createActualVsPlanWorkbook,
+  generateStandardFormFilename,
+  generateActualVsPlanFilename,
+} from '../exportExcel';
+import type { StaffSchedule, Staff, FacilityShiftSettings } from '../../../types';
+import { Qualification, TimeSlotPreference } from '../../../types';
+import { Timestamp } from 'firebase/firestore';
+
+// ==================== フィクスチャ ====================
+
+const makeTimestamp = () => ({ toDate: () => new Date() } as unknown as Timestamp);
+
+const mockShiftSettings: FacilityShiftSettings = {
+  facilityId: 'fac-1',
+  shiftTypes: [
+    { id: 'day',    name: '日勤',    start: '09:00', end: '18:00', restHours: 1, color: { background: '', text: '' }, isActive: true, sortOrder: 1 },
+    { id: 'early',  name: '早番',    start: '07:00', end: '16:00', restHours: 1, color: { background: '', text: '' }, isActive: true, sortOrder: 2 },
+    { id: 'night',  name: '夜勤',    start: '16:00', end: '09:00', restHours: 2, color: { background: '', text: '' }, isActive: true, sortOrder: 3 },
+    { id: 'off',    name: '休',      start: '',      end: '',      restHours: 0, color: { background: '', text: '' }, isActive: true, sortOrder: 4 },
+    { id: 'postnight', name: '明け休み', start: '', end: '', restHours: 0, color: { background: '', text: '' }, isActive: true, sortOrder: 5 },
+  ],
+  defaultShiftCycle: [],
+  updatedAt: makeTimestamp(),
+  updatedBy: 'test',
+};
+
+const mockStaff: Staff[] = [
+  {
+    id: 's1',
+    name: '田中太郎',
+    role: '介護職員' as any,
+    qualifications: [Qualification.CertifiedCareWorker],
+    weeklyWorkCount: { hope: 5, must: 4 },
+    maxConsecutiveWorkDays: 5,
+    availableWeekdays: [0, 1, 2, 3, 4, 5, 6],
+    unavailableDates: [],
+    timeSlotPreference: TimeSlotPreference.DayOnly,
+    isNightShiftOnly: false,
+    employmentType: 'A',
+  },
+  {
+    id: 's2',
+    name: '佐藤花子',
+    role: '看護職員' as any,
+    qualifications: [Qualification.RegisteredNurse],
+    weeklyWorkCount: { hope: 3, must: 2 },
+    maxConsecutiveWorkDays: 5,
+    availableWeekdays: [0, 1, 2, 3, 4, 5, 6],
+    unavailableDates: [],
+    timeSlotPreference: TimeSlotPreference.DayOnly,
+    isNightShiftOnly: false,
+    employmentType: 'C',
+    weeklyContractHours: 20,
+  },
+];
+
+const mockSchedules: StaffSchedule[] = [
+  {
+    staffId: 's1',
+    staffName: '田中太郎',
+    monthlyShifts: [
+      { date: '2025-01-01', plannedShiftType: '日勤' },
+      { date: '2025-01-02', plannedShiftType: '早番' },
+      { date: '2025-01-03', plannedShiftType: '休' },
+    ],
+  },
+  {
+    staffId: 's2',
+    staffName: '佐藤花子',
+    monthlyShifts: [
+      { date: '2025-01-01', plannedShiftType: '休' },
+      { date: '2025-01-02', plannedShiftType: '日勤', actualShiftType: '早番', actualStartTime: '07:00', actualEndTime: '16:00' },
+      { date: '2025-01-03', plannedShiftType: '日勤' },
+    ],
+  },
+];
+
+// ==================== generateFilename ====================
+
+describe('generateStandardFormFilename', () => {
+  it('正しいファイル名を生成する', () => {
+    expect(generateStandardFormFilename('2025-01')).toBe('勤務形態一覧表_202501.xlsx');
+    expect(generateStandardFormFilename('2024-12')).toBe('勤務形態一覧表_202412.xlsx');
+  });
+});
+
+describe('generateActualVsPlanFilename', () => {
+  it('正しいファイル名を生成する', () => {
+    expect(generateActualVsPlanFilename('2025-01')).toBe('勤務形態一覧表_予実_202501.xlsx');
+    expect(generateActualVsPlanFilename('2024-12')).toBe('勤務形態一覧表_予実_202412.xlsx');
+  });
+});
+
+// ==================== createStandardFormWorkbook ====================
+
+describe('createStandardFormWorkbook', () => {
+  it('Workbookオブジェクトを返す', async () => {
+    const wb = await createStandardFormWorkbook(
+      mockSchedules, mockStaff, mockShiftSettings, 'テスト施設', '2025-01'
+    );
+    expect(wb).toBeDefined();
+    expect(wb.worksheets).toHaveLength(1);
+  });
+
+  it('シート名が正しい', async () => {
+    const wb = await createStandardFormWorkbook(
+      mockSchedules, mockStaff, mockShiftSettings, 'テスト施設', '2025-01'
+    );
+    expect(wb.worksheets[0].name).toBe('勤務形態一覧表');
+  });
+
+  it('タイトル行に正しいテキストが含まれる', async () => {
+    const wb = await createStandardFormWorkbook(
+      mockSchedules, mockStaff, mockShiftSettings, 'テスト施設', '2025-01'
+    );
+    const ws = wb.worksheets[0];
+    const titleCell = ws.getRow(1).getCell(2);
+    expect(titleCell.value).toContain('従業者の勤務の体制及び勤務形態一覧表');
+  });
+
+  it('施設名・対象月がヘッダーに含まれる', async () => {
+    const wb = await createStandardFormWorkbook(
+      mockSchedules, mockStaff, mockShiftSettings, 'テスト施設', '2025-01'
+    );
+    const ws = wb.worksheets[0];
+    const row2 = ws.getRow(2);
+    expect(String(row2.getCell(2).value)).toContain('テスト施設');
+    expect(String(row2.getCell(5).value)).toContain('令和7年1月');
+  });
+
+  it('スタッフ名が正しく出力される', async () => {
+    const wb = await createStandardFormWorkbook(
+      mockSchedules, mockStaff, mockShiftSettings, 'テスト施設', '2025-01'
+    );
+    const ws = wb.worksheets[0];
+    // 行5以降がスタッフデータ行
+    const staffNames = [ws.getRow(5).getCell(2).value, ws.getRow(6).getCell(2).value];
+    expect(staffNames).toContain('田中太郎');
+    expect(staffNames).toContain('佐藤花子');
+  });
+
+  it('空のスケジュールでもエラーなく生成できる', async () => {
+    const wb = await createStandardFormWorkbook(
+      [], [], mockShiftSettings, 'テスト施設', '2025-01'
+    );
+    expect(wb).toBeDefined();
+  });
+
+  it('1月（31日）の列数が正しい（固定5列 + 31日 + 集計2列 = 38列）', async () => {
+    const wb = await createStandardFormWorkbook(
+      mockSchedules, mockStaff, mockShiftSettings, 'テスト施設', '2025-01'
+    );
+    const ws = wb.worksheets[0];
+    const headerRow = ws.getRow(4);
+    // COL_FTE = 6(DAY_START) + 31(days) + 1(totalHours) + 1(fte) = 39... 実際はCOL_TOTAL_HOURS=37, COL_FTE=38
+    // COL_DAYS_START=6, daysInMonth=31 → COL_TOTAL_HOURS=6+31=37, COL_FTE=38
+    expect(headerRow.getCell(38).value).toContain('換算');
+  });
+
+  it('2月（28日）の列数が正しい（固定5列 + 28日 + 集計2列 = 35列）', async () => {
+    const schedFeb = [{
+      staffId: 's1', staffName: '田中太郎',
+      monthlyShifts: [{ date: '2025-02-01', plannedShiftType: '日勤' }],
+    }];
+    const wb = await createStandardFormWorkbook(
+      schedFeb, mockStaff, mockShiftSettings, 'テスト施設', '2025-02'
+    );
+    const ws = wb.worksheets[0];
+    const headerRow = ws.getRow(4);
+    // COL_DAYS_START=6, daysInMonth=28 → COL_TOTAL_HOURS=6+28=34, COL_FTE=35
+    expect(headerRow.getCell(35).value).toContain('換算');
+  });
+});
+
+// ==================== createActualVsPlanWorkbook ====================
+
+describe('createActualVsPlanWorkbook', () => {
+  it('Workbookオブジェクトを返す', async () => {
+    const wb = await createActualVsPlanWorkbook(
+      mockSchedules, mockStaff, mockShiftSettings, 'テスト施設', '2025-01'
+    );
+    expect(wb).toBeDefined();
+    expect(wb.worksheets).toHaveLength(1);
+  });
+
+  it('シート名が正しい', async () => {
+    const wb = await createActualVsPlanWorkbook(
+      mockSchedules, mockStaff, mockShiftSettings, 'テスト施設', '2025-01'
+    );
+    expect(wb.worksheets[0].name).toBe('予実勤務形態一覧表');
+  });
+
+  it('タイトルに予実が含まれる', async () => {
+    const wb = await createActualVsPlanWorkbook(
+      mockSchedules, mockStaff, mockShiftSettings, 'テスト施設', '2025-01'
+    );
+    const ws = wb.worksheets[0];
+    const titleCell = ws.getRow(1).getCell(1);
+    expect(String(titleCell.value)).toContain('予実');
+  });
+
+  it('スタッフごとに2行（予定・実績）が生成される', async () => {
+    const wb = await createActualVsPlanWorkbook(
+      mockSchedules, mockStaff, mockShiftSettings, 'テスト施設', '2025-01'
+    );
+    const ws = wb.worksheets[0];
+    // 2スタッフ → データ行は4（行4以降）から始まり2行ずつ
+    const planLabel1 = ws.getRow(4).getCell(4).value; // 1人目・予定
+    const actualLabel1 = ws.getRow(5).getCell(4).value; // 1人目・実績
+    expect(planLabel1).toBe('予');
+    expect(actualLabel1).toBe('実');
+  });
+
+  it('空のスケジュールでもエラーなく生成できる', async () => {
+    const wb = await createActualVsPlanWorkbook(
+      [], [], mockShiftSettings, 'テスト施設', '2025-01'
+    );
+    expect(wb).toBeDefined();
+  });
+});

--- a/src/utils/exportExcel.ts
+++ b/src/utils/exportExcel.ts
@@ -1,0 +1,579 @@
+/**
+ * exportExcel.ts
+ *
+ * Phase 25: Excel エクスポートユーティリティ
+ *
+ * 機能:
+ * 1. 標準様式第1号出力（行政提出用）
+ *    - 厚生労働省標準様式「従業者の勤務の体制及び勤務形態一覧表」準拠
+ *    - 予定シフトのみ、FTE付き
+ * 2. 予実2段書き出力（内部管理用）
+ *    - 各日に予定・実績を2行で表示
+ *    - 差異セルをオレンジ色ハイライト
+ */
+
+import ExcelJS from 'exceljs';
+import type { StaffSchedule, Staff, FacilityShiftSettings } from '../../types';
+import { EMPLOYMENT_TYPES } from '../../constants';
+import { calculateFullTimeEquivalent } from '../services/complianceService';
+
+// ==================== 定数 ====================
+
+// シフト略称マップ（日本語省略表記）
+const SHIFT_ABBREV: Record<string, string> = {
+  '早番': '早',
+  '日勤': '日',
+  '遅番': '遅',
+  '夜勤': '夜',
+  '明け休み': '明',
+  '休': '休',
+  '有給休暇': '有',
+  '研修': '研',
+};
+
+/**
+ * シフトタイプ名を略称に変換（定義なければ先頭1文字）
+ */
+function toAbbrev(shiftTypeName: string): string {
+  return SHIFT_ABBREV[shiftTypeName] ?? (shiftTypeName.charAt(0) || '');
+}
+
+/**
+ * 対象月（YYYY-MM）の全日付リストを返す
+ */
+function getDatesInMonth(targetMonth: string): string[] {
+  const [year, month] = targetMonth.split('-').map(Number);
+  const daysInMonth = new Date(year, month, 0).getDate();
+  return Array.from({ length: daysInMonth }, (_, i) => {
+    const day = i + 1;
+    return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+  });
+}
+
+/**
+ * YYYY-MM → 令和/年月表記（例: 令和7年1月）
+ */
+function formatTargetMonthJa(targetMonth: string): string {
+  const [year, month] = targetMonth.split('-').map(Number);
+  // 令和元年 = 2019年
+  const reiwaYear = year - 2018;
+  if (reiwaYear >= 1) {
+    return `令和${reiwaYear}年${month}月`;
+  }
+  return `${year}年${month}月`;
+}
+
+/**
+ * 共通スタイル定義
+ */
+const STYLES = {
+  titleFont: { bold: true, size: 14 },
+  headerFont: { bold: true, size: 10 },
+  headerFill: {
+    type: 'pattern' as const,
+    pattern: 'solid' as const,
+    fgColor: { argb: 'FFD0E4F7' },
+  },
+  borderThin: {
+    top: { style: 'thin' as const },
+    left: { style: 'thin' as const },
+    bottom: { style: 'thin' as const },
+    right: { style: 'thin' as const },
+  },
+  alignCenter: { horizontal: 'center' as const, vertical: 'middle' as const },
+  alignLeft: { horizontal: 'left' as const, vertical: 'middle' as const },
+  diffFill: {
+    type: 'pattern' as const,
+    pattern: 'solid' as const,
+    fgColor: { argb: 'FFFFA500' }, // オレンジ（差異ハイライト）
+  },
+};
+
+// ==================== 標準様式第1号 ====================
+
+/**
+ * 標準様式第1号「従業者の勤務の体制及び勤務形態一覧表」を生成
+ *
+ * 行政提出用（予定シフトのみ）
+ *
+ * @param staffSchedules - 対象月のスタッフスケジュール一覧
+ * @param staffList - スタッフ情報一覧
+ * @param shiftSettings - 施設シフト設定
+ * @param facilityName - 施設名
+ * @param targetMonth - 対象月（YYYY-MM）
+ * @param standardWeeklyHours - 常勤週所定労働時間（デフォルト40h）
+ * @returns ExcelJS Workbook
+ */
+export async function createStandardFormWorkbook(
+  staffSchedules: StaffSchedule[],
+  staffList: Staff[],
+  shiftSettings: FacilityShiftSettings,
+  facilityName: string,
+  targetMonth: string,
+  standardWeeklyHours: number = 40
+): Promise<ExcelJS.Workbook> {
+  const workbook = new ExcelJS.Workbook();
+  workbook.creator = 'AI介護シフトスケジューラー';
+  workbook.created = new Date();
+
+  const worksheet = workbook.addWorksheet('勤務形態一覧表', {
+    pageSetup: {
+      paperSize: 9, // A4
+      orientation: 'landscape',
+      fitToPage: true,
+      fitToWidth: 1,
+      fitToHeight: 0,
+    },
+  });
+
+  const dates = getDatesInMonth(targetMonth);
+  const daysInMonth = dates.length;
+
+  // FTE計算（予定ベース）
+  const fteEntries = calculateFullTimeEquivalent(
+    staffSchedules, staffList, shiftSettings, standardWeeklyHours, false
+  );
+
+  // ==================== 列定義 ====================
+  // 固定列: 番号(1), 氏名(2), 職種(3), 資格(4), 常勤区分(5)
+  // 日付列: 6 + day - 1
+  // 集計列: 月間勤務時間, 常勤換算値
+  const COL_NO = 1;
+  const COL_NAME = 2;
+  const COL_ROLE = 3;
+  const COL_QUAL = 4;
+  const COL_EMP = 5;
+  const COL_DAYS_START = 6;
+  const COL_TOTAL_HOURS = COL_DAYS_START + daysInMonth;
+  const COL_FTE = COL_TOTAL_HOURS + 1;
+  const totalCols = COL_FTE;
+
+  // 列幅設定
+  worksheet.getColumn(COL_NO).width = 4;
+  worksheet.getColumn(COL_NAME).width = 12;
+  worksheet.getColumn(COL_ROLE).width = 10;
+  worksheet.getColumn(COL_QUAL).width = 12;
+  worksheet.getColumn(COL_EMP).width = 8;
+  for (let d = 0; d < daysInMonth; d++) {
+    worksheet.getColumn(COL_DAYS_START + d).width = 3.2;
+  }
+  worksheet.getColumn(COL_TOTAL_HOURS).width = 9;
+  worksheet.getColumn(COL_FTE).width = 8;
+
+  // ==================== 行1: タイトル ====================
+  const titleRow = worksheet.getRow(1);
+  const titleCell = titleRow.getCell(COL_NAME);
+  titleCell.value = '従業者の勤務の体制及び勤務形態一覧表';
+  titleCell.font = STYLES.titleFont;
+  titleCell.alignment = STYLES.alignLeft;
+  worksheet.mergeCells(1, COL_NAME, 1, totalCols);
+  titleRow.height = 24;
+
+  // ==================== 行2: 施設名・対象月 ====================
+  const infoRow = worksheet.getRow(2);
+  infoRow.getCell(COL_NAME).value = `事業所名: ${facilityName}`;
+  infoRow.getCell(COL_NAME).font = { size: 10 };
+  infoRow.getCell(COL_EMP).value = `対象月: ${formatTargetMonthJa(targetMonth)}`;
+  infoRow.getCell(COL_EMP).font = { size: 10 };
+  infoRow.height = 18;
+
+  // ==================== 行4: ヘッダー ====================
+  const headerRow = worksheet.getRow(4);
+  headerRow.height = 28;
+
+  const setHeader = (col: number, value: string) => {
+    const cell = headerRow.getCell(col);
+    cell.value = value;
+    cell.font = STYLES.headerFont;
+    cell.fill = STYLES.headerFill;
+    cell.alignment = { ...STYLES.alignCenter, wrapText: true };
+    cell.border = STYLES.borderThin;
+  };
+
+  setHeader(COL_NO, 'No.');
+  setHeader(COL_NAME, '職員氏名');
+  setHeader(COL_ROLE, '職種');
+  setHeader(COL_QUAL, '資格');
+  setHeader(COL_EMP, '勤務\n形態');
+
+  // 日付ヘッダー（1〜daysInMonth）
+  for (let d = 0; d < daysInMonth; d++) {
+    const date = new Date(dates[d]);
+    const day = date.getDate();
+    const weekDay = ['日', '月', '火', '水', '木', '金', '土'][date.getDay()];
+    const isWeekend = date.getDay() === 0 || date.getDay() === 6;
+    const cell = headerRow.getCell(COL_DAYS_START + d);
+    cell.value = `${day}\n${weekDay}`;
+    cell.font = {
+      bold: true,
+      size: 9,
+      color: isWeekend ? { argb: 'FFCC0000' } : undefined,
+    };
+    cell.fill = STYLES.headerFill;
+    cell.alignment = { ...STYLES.alignCenter, wrapText: true };
+    cell.border = STYLES.borderThin;
+  }
+
+  setHeader(COL_TOTAL_HOURS, '月間\n勤務時間');
+  setHeader(COL_FTE, '常勤\n換算値');
+
+  // ==================== 行5+: スタッフデータ ====================
+  staffSchedules.forEach((ss, idx) => {
+    const staff = staffList.find((s) => s.id === ss.staffId);
+    const fteEntry = fteEntries.find((e) => e.staffId === ss.staffId);
+    const empType = staff?.employmentType ?? 'A';
+    const empLabel = `${empType}: ${EMPLOYMENT_TYPES[empType]}`;
+
+    const row = worksheet.getRow(5 + idx);
+    row.height = 16;
+
+    const setCell = (col: number, value: ExcelJS.CellValue, opts?: Partial<ExcelJS.Style>) => {
+      const cell = row.getCell(col);
+      cell.value = value;
+      cell.font = { size: 9, ...opts?.font };
+      cell.alignment = { ...STYLES.alignCenter, ...opts?.alignment };
+      cell.border = STYLES.borderThin;
+      if (opts?.fill) cell.fill = opts.fill;
+    };
+
+    setCell(COL_NO, idx + 1);
+    setCell(COL_NAME, ss.staffName, { alignment: { horizontal: 'left', vertical: 'middle' } });
+    setCell(COL_ROLE, staff?.role ?? '');
+    setCell(COL_QUAL, staff?.qualifications?.join(', ') ?? '');
+    setCell(COL_EMP, empLabel, { alignment: { horizontal: 'left', vertical: 'middle' } });
+
+    // 各日シフト
+    dates.forEach((date, d) => {
+      const shift = ss.monthlyShifts.find((s) => s.date === date);
+      const shiftName = shift?.plannedShiftType ?? '';
+      const abbrev = shiftName ? toAbbrev(shiftName) : '';
+
+      const isWeekend = new Date(date).getDay() === 0 || new Date(date).getDay() === 6;
+      setCell(COL_DAYS_START + d, abbrev, {
+        font: {
+          size: 9,
+          color: isWeekend ? { argb: 'FFCC0000' } : undefined,
+        },
+      });
+    });
+
+    // 集計
+    setCell(COL_TOTAL_HOURS, fteEntry?.monthlyHours ?? 0);
+    setCell(COL_FTE, fteEntry?.fteValue ?? 0);
+  });
+
+  // ==================== 行(最終+2): 合計行 ====================
+  const totalRowIdx = 5 + staffSchedules.length + 1;
+  const totalRow = worksheet.getRow(totalRowIdx);
+  totalRow.height = 18;
+
+  const totalFTE = fteEntries.reduce((sum, e) => sum + e.fteValue, 0);
+  const totalHours = fteEntries.reduce((sum, e) => sum + e.monthlyHours, 0);
+
+  const setTotalCell = (col: number, value: ExcelJS.CellValue) => {
+    const cell = totalRow.getCell(col);
+    cell.value = value;
+    cell.font = { bold: true, size: 10 };
+    cell.alignment = STYLES.alignCenter;
+    cell.border = STYLES.borderThin;
+    cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFFF3CD' } };
+  };
+
+  setTotalCell(COL_NO, '合計');
+  worksheet.mergeCells(totalRowIdx, COL_NO, totalRowIdx, COL_EMP);
+  setTotalCell(COL_TOTAL_HOURS, Math.round(totalHours * 10) / 10);
+  setTotalCell(COL_FTE, Math.round(totalFTE * 100) / 100);
+
+  // ==================== 行(最終+3): 注記 ====================
+  const noteRow = worksheet.getRow(totalRowIdx + 1);
+  const noteCell = noteRow.getCell(COL_NO);
+  noteCell.value =
+    `※ 常勤換算値 = 月間勤務時間 ÷ (週所定労働時間${standardWeeklyHours}h × 4.33週)　` +
+    '略称: 早=早番 日=日勤 遅=遅番 夜=夜勤 明=明け休み 休=休日 有=有給';
+  noteCell.font = { size: 8, color: { argb: 'FF666666' } };
+  worksheet.mergeCells(totalRowIdx + 1, COL_NO, totalRowIdx + 1, totalCols);
+
+  return workbook;
+}
+
+// ==================== 予実2段書き ====================
+
+/**
+ * 予実2段書きExcelを生成（内部管理用）
+ *
+ * 各日に「予定」「実績」を2行表示。差異セルはオレンジハイライト。
+ *
+ * @param staffSchedules - 対象月のスタッフスケジュール一覧
+ * @param staffList - スタッフ情報一覧
+ * @param shiftSettings - 施設シフト設定
+ * @param facilityName - 施設名
+ * @param targetMonth - 対象月（YYYY-MM）
+ * @param standardWeeklyHours - 常勤週所定労働時間（デフォルト40h）
+ * @returns ExcelJS Workbook
+ */
+export async function createActualVsPlanWorkbook(
+  staffSchedules: StaffSchedule[],
+  staffList: Staff[],
+  shiftSettings: FacilityShiftSettings,
+  facilityName: string,
+  targetMonth: string,
+  standardWeeklyHours: number = 40
+): Promise<ExcelJS.Workbook> {
+  const workbook = new ExcelJS.Workbook();
+  workbook.creator = 'AI介護シフトスケジューラー';
+  workbook.created = new Date();
+
+  const worksheet = workbook.addWorksheet('予実勤務形態一覧表', {
+    pageSetup: {
+      paperSize: 9,
+      orientation: 'landscape',
+      fitToPage: true,
+      fitToWidth: 1,
+      fitToHeight: 0,
+    },
+  });
+
+  const dates = getDatesInMonth(targetMonth);
+  const daysInMonth = dates.length;
+
+  // FTE（予定・実績 両方）
+  const ftePlan = calculateFullTimeEquivalent(
+    staffSchedules, staffList, shiftSettings, standardWeeklyHours, false
+  );
+  const fteActual = calculateFullTimeEquivalent(
+    staffSchedules, staffList, shiftSettings, standardWeeklyHours, true
+  );
+
+  // 列定義
+  const COL_NAME = 1;
+  const COL_ROLE = 2;
+  const COL_EMP = 3;
+  const COL_TYPE = 4; // 予定/実績
+  const COL_DAYS_START = 5;
+  const COL_TOTAL_HOURS = COL_DAYS_START + daysInMonth;
+  const COL_FTE = COL_TOTAL_HOURS + 1;
+  const totalCols = COL_FTE;
+
+  // 列幅
+  worksheet.getColumn(COL_NAME).width = 12;
+  worksheet.getColumn(COL_ROLE).width = 10;
+  worksheet.getColumn(COL_EMP).width = 7;
+  worksheet.getColumn(COL_TYPE).width = 4;
+  for (let d = 0; d < daysInMonth; d++) {
+    worksheet.getColumn(COL_DAYS_START + d).width = 3.2;
+  }
+  worksheet.getColumn(COL_TOTAL_HOURS).width = 9;
+  worksheet.getColumn(COL_FTE).width = 8;
+
+  // タイトル
+  const titleRow = worksheet.getRow(1);
+  const titleCell = titleRow.getCell(COL_NAME);
+  titleCell.value = `${facilityName} 勤務形態一覧表（予実）　${formatTargetMonthJa(targetMonth)}`;
+  titleCell.font = STYLES.titleFont;
+  worksheet.mergeCells(1, COL_NAME, 1, totalCols);
+  titleRow.height = 22;
+
+  // ヘッダー行
+  const headerRow = worksheet.getRow(3);
+  headerRow.height = 28;
+
+  const setHeader = (col: number, value: string) => {
+    const cell = headerRow.getCell(col);
+    cell.value = value;
+    cell.font = STYLES.headerFont;
+    cell.fill = STYLES.headerFill;
+    cell.alignment = { ...STYLES.alignCenter, wrapText: true };
+    cell.border = STYLES.borderThin;
+  };
+
+  setHeader(COL_NAME, '職員氏名');
+  setHeader(COL_ROLE, '職種');
+  setHeader(COL_EMP, '勤務\n形態');
+  setHeader(COL_TYPE, '予/実');
+
+  for (let d = 0; d < daysInMonth; d++) {
+    const date = new Date(dates[d]);
+    const day = date.getDate();
+    const weekDay = ['日', '月', '火', '水', '木', '金', '土'][date.getDay()];
+    const isWeekend = date.getDay() === 0 || date.getDay() === 6;
+    const cell = headerRow.getCell(COL_DAYS_START + d);
+    cell.value = `${day}\n${weekDay}`;
+    cell.font = {
+      bold: true,
+      size: 9,
+      color: isWeekend ? { argb: 'FFCC0000' } : undefined,
+    };
+    cell.fill = STYLES.headerFill;
+    cell.alignment = { ...STYLES.alignCenter, wrapText: true };
+    cell.border = STYLES.borderThin;
+  }
+
+  setHeader(COL_TOTAL_HOURS, '月間\n勤務時間');
+  setHeader(COL_FTE, '常勤\n換算値');
+
+  // スタッフデータ（1スタッフにつき2行: 予定行・実績行）
+  let currentDataRow = 4;
+
+  staffSchedules.forEach((ss, _idx) => {
+    const staff = staffList.find((s) => s.id === ss.staffId);
+    const planEntry = ftePlan.find((e) => e.staffId === ss.staffId);
+    const actualEntry = fteActual.find((e) => e.staffId === ss.staffId);
+    const empType = staff?.employmentType ?? 'A';
+
+    const planRow = worksheet.getRow(currentDataRow);
+    const actualRow = worksheet.getRow(currentDataRow + 1);
+    planRow.height = 14;
+    actualRow.height = 14;
+
+    // 氏名・職種・勤務形態（予定行のみ、2行マージ）
+    const nameCell = planRow.getCell(COL_NAME);
+    nameCell.value = ss.staffName;
+    nameCell.font = { bold: true, size: 9 };
+    nameCell.alignment = { ...STYLES.alignLeft, vertical: 'middle' };
+    nameCell.border = STYLES.borderThin;
+    worksheet.mergeCells(currentDataRow, COL_NAME, currentDataRow + 1, COL_NAME);
+
+    const roleCell = planRow.getCell(COL_ROLE);
+    roleCell.value = staff?.role ?? '';
+    roleCell.font = { size: 9 };
+    roleCell.alignment = STYLES.alignCenter;
+    roleCell.border = STYLES.borderThin;
+    worksheet.mergeCells(currentDataRow, COL_ROLE, currentDataRow + 1, COL_ROLE);
+
+    const empCell = planRow.getCell(COL_EMP);
+    empCell.value = empType;
+    empCell.font = { size: 9 };
+    empCell.alignment = STYLES.alignCenter;
+    empCell.border = STYLES.borderThin;
+    worksheet.mergeCells(currentDataRow, COL_EMP, currentDataRow + 1, COL_EMP);
+
+    // 予定/実績ラベル
+    const setPRLabel = (row: ExcelJS.Row, label: string) => {
+      const cell = row.getCell(COL_TYPE);
+      cell.value = label;
+      cell.font = { size: 8, italic: true };
+      cell.alignment = STYLES.alignCenter;
+      cell.border = STYLES.borderThin;
+      cell.fill = label === '予'
+        ? { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFE8F5E9' } }
+        : { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFCE4EC' } };
+    };
+    setPRLabel(planRow, '予');
+    setPRLabel(actualRow, '実');
+
+    // 各日シフト
+    dates.forEach((date, d) => {
+      const shift = ss.monthlyShifts.find((s) => s.date === date);
+      const planned = shift?.plannedShiftType ?? '';
+      const actual = shift?.actualShiftType ?? '';
+      const hasDiff = actual !== '' && actual !== planned;
+
+      const isWeekend = new Date(date).getDay() === 0 || new Date(date).getDay() === 6;
+      const weekendColor = { argb: 'FFCC0000' };
+
+      // 予定セル
+      const pCell = planRow.getCell(COL_DAYS_START + d);
+      pCell.value = planned ? toAbbrev(planned) : '';
+      pCell.font = { size: 9, color: isWeekend ? weekendColor : undefined };
+      pCell.alignment = STYLES.alignCenter;
+      pCell.border = STYLES.borderThin;
+      pCell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFE8F5E9' } };
+
+      // 実績セル
+      const aCell = actualRow.getCell(COL_DAYS_START + d);
+      aCell.value = actual ? toAbbrev(actual) : '';
+      aCell.font = { size: 9, color: isWeekend ? weekendColor : undefined };
+      aCell.alignment = STYLES.alignCenter;
+      aCell.border = STYLES.borderThin;
+      // 差異があればオレンジハイライト
+      aCell.fill = hasDiff
+        ? STYLES.diffFill
+        : { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFCE4EC' } };
+    });
+
+    // 集計（予定行）
+    const setAgg = (row: ExcelJS.Row, hours: number, fte: number) => {
+      const hCell = row.getCell(COL_TOTAL_HOURS);
+      hCell.value = hours;
+      hCell.font = { size: 9 };
+      hCell.alignment = STYLES.alignCenter;
+      hCell.border = STYLES.borderThin;
+
+      const fCell = row.getCell(COL_FTE);
+      fCell.value = fte;
+      fCell.font = { size: 9 };
+      fCell.alignment = STYLES.alignCenter;
+      fCell.border = STYLES.borderThin;
+    };
+    setAgg(planRow, planEntry?.monthlyHours ?? 0, planEntry?.fteValue ?? 0);
+    setAgg(actualRow, actualEntry?.monthlyHours ?? 0, actualEntry?.fteValue ?? 0);
+
+    // 集計列をマージ（FTEのみ）
+    worksheet.mergeCells(currentDataRow, COL_FTE, currentDataRow + 1, COL_FTE);
+
+    currentDataRow += 2;
+  });
+
+  // 凡例行
+  const legendRow = worksheet.getRow(currentDataRow + 1);
+  const legendCell = legendRow.getCell(COL_NAME);
+  legendCell.value =
+    '凡例: 予=予定シフト 実=実績シフト オレンジ=予実差異あり　' +
+    '略称: 早=早番 日=日勤 遅=遅番 夜=夜勤 明=明け休み 休=休日 有=有給';
+  legendCell.font = { size: 8, color: { argb: 'FF666666' } };
+  worksheet.mergeCells(currentDataRow + 1, COL_NAME, currentDataRow + 1, totalCols);
+
+  return workbook;
+}
+
+// ==================== ダウンロードヘルパー ====================
+
+/**
+ * ExcelJS Workbook をブラウザでダウンロード
+ *
+ * @param workbook - ExcelJS Workbook
+ * @param filename - ファイル名（例: 勤務形態一覧表_202501.xlsx）
+ */
+export async function downloadExcel(
+  workbook: ExcelJS.Workbook,
+  filename: string
+): Promise<void> {
+  const buffer = await workbook.xlsx.writeBuffer();
+  const blob = new Blob([buffer], {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  });
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.setAttribute('href', url);
+  link.setAttribute('download', filename);
+  link.style.visibility = 'hidden';
+
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * ファイル名を生成（標準様式第1号）
+ *
+ * @param targetMonth - YYYY-MM
+ * @returns 例: 勤務形態一覧表_202501.xlsx
+ */
+export function generateStandardFormFilename(targetMonth: string): string {
+  const ym = targetMonth.replace('-', '');
+  return `勤務形態一覧表_${ym}.xlsx`;
+}
+
+/**
+ * ファイル名を生成（予実2段書き）
+ *
+ * @param targetMonth - YYYY-MM
+ * @returns 例: 勤務形態一覧表_予実_202501.xlsx
+ */
+export function generateActualVsPlanFilename(targetMonth: string): string {
+  const ym = targetMonth.replace('-', '');
+  return `勤務形態一覧表_予実_${ym}.xlsx`;
+}


### PR DESCRIPTION
## Summary

- `src/utils/exportExcel.ts` を新規追加
- ExcelJS 4.4.0 をインストール
- ユニットテスト 15件

## 変更内容

### 新規: `src/utils/exportExcel.ts`

| 関数 | 説明 |
|------|------|
| `createStandardFormWorkbook` | 標準様式第1号「従業者の勤務の体制及び勤務形態一覧表」（行政提出用） |
| `createActualVsPlanWorkbook` | 予実2段書き（内部管理用） |
| `downloadExcel` | ブラウザダウンロードヘルパー |
| `generateStandardFormFilename` | ファイル名生成（例: `勤務形態一覧表_202501.xlsx`） |
| `generateActualVsPlanFilename` | ファイル名生成（例: `勤務形態一覧表_予実_202501.xlsx`） |

### 標準様式第1号の仕様

- 厚生労働省標準様式準拠
- タイトル「従業者の勤務の体制及び勤務形態一覧表」
- 令和年表記、施設名・対象月ヘッダー
- 各スタッフ: 職員氏名・職種・資格・勤務形態区分・各日シフト略称・月間勤務時間・常勤換算値
- 土日赤字表示、合計行、注記行

### 予実2段書きの仕様

- 各日に予定行（緑）・実績行（赤）を2行で表示
- 差異セル（予定≠実績）をオレンジ色でハイライト

## Test plan

- [x] `npx vitest run src/utils/__tests__/exportExcel.test.ts` → 15件全通過
- [x] `npx vitest run` → 204件全通過
- [x] `npx tsc --noEmit` → 型エラーなし

## 依存関係

- PR #85（complianceService）の `calculateFullTimeEquivalent` を使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)