### PR TITLE
feat: コンプライアンスチェックUIを追加（Phase 25 #E）

### DIFF
--- a/src/pages/reports/ComplianceContent.tsx
+++ b/src/pages/reports/ComplianceContent.tsx
@@ -1,0 +1,358 @@
+/**
+ * ComplianceContent.tsx
+ *
+ * Phase 25 #E: コンプライアンスチェックタブのUIコンポーネント
+ *
+ * 表示内容:
+ * - 常勤換算（FTE）テーブル（スタッフ別）
+ * - 役職別FTE合計
+ * - 違反一覧（労基法・インターバル）
+ * - Excel ダウンロードボタン
+ */
+
+import React, { useState, useMemo, useCallback } from 'react';
+import type {
+  StaffSchedule,
+  Staff,
+  FacilityShiftSettings,
+  ComplianceViolationItem,
+  FullTimeEquivalentEntry,
+} from '../../../types';
+import { runComplianceCheck } from '../../services/complianceService';
+import { DEFAULT_STANDARD_WEEKLY_HOURS } from '../../../constants';
+
+interface ComplianceContentProps {
+  staffSchedules: StaffSchedule[];
+  staffList: Staff[];
+  shiftSettings: FacilityShiftSettings;
+  facilityName: string;
+  targetMonth: string;
+}
+
+// 重大度バッジのスタイルマップ
+const SEVERITY_STYLES: Record<ComplianceViolationItem['severity'], string> = {
+  error: 'bg-red-100 text-red-800 border border-red-200',
+  warning: 'bg-yellow-100 text-yellow-800 border border-yellow-200',
+};
+
+const SEVERITY_LABELS: Record<ComplianceViolationItem['severity'], string> = {
+  error: '違反',
+  warning: '注意',
+};
+
+const TYPE_LABELS: Record<ComplianceViolationItem['type'], string> = {
+  break_time: '休憩時間',
+  rest_interval: '勤務間インターバル',
+};
+
+// 雇用形態の表示名
+const EMP_TYPE_LABELS: Record<string, string> = {
+  A: '常勤（フルタイム）',
+  B: '常勤（短時間）',
+  C: '非常勤（パートタイム）',
+  D: '非常勤（その他）',
+};
+
+function SummaryCard({ label, value, colorClass }: { label: string; value: string | number; colorClass: string }) {
+  return (
+    <div className={`rounded-lg p-4 ${colorClass}`}>
+      <p className="text-sm font-medium opacity-80">{label}</p>
+      <p className="text-2xl font-bold mt-1">{value}</p>
+    </div>
+  );
+}
+
+export function ComplianceContent({
+  staffSchedules,
+  staffList,
+  shiftSettings,
+  facilityName,
+  targetMonth,
+}: ComplianceContentProps): React.ReactElement {
+  const [useActual, setUseActual] = useState(false);
+  const [standardWeeklyHours, setStandardWeeklyHours] = useState(DEFAULT_STANDARD_WEEKLY_HOURS);
+  const [isExporting, setIsExporting] = useState(false);
+
+  // コンプライアンスチェック実行（メモ化）
+  const result = useMemo(
+    () =>
+      runComplianceCheck(
+        staffSchedules,
+        staffList,
+        shiftSettings,
+        targetMonth,
+        standardWeeklyHours,
+        useActual
+      ),
+    [staffSchedules, staffList, shiftSettings, targetMonth, standardWeeklyHours, useActual]
+  );
+
+  const errorCount = result.violations.filter((v) => v.severity === 'error').length;
+  const warningCount = result.violations.filter((v) => v.severity === 'warning').length;
+  const totalFte = (Object.values(result.fteTotalByRole) as number[]).reduce((sum, v) => sum + v, 0);
+
+  // Excel エクスポート
+  const handleExcelExport = useCallback(async () => {
+    setIsExporting(true);
+    try {
+      const { createStandardFormWorkbook, downloadExcel, generateStandardFormFilename } =
+        await import('../../utils/exportExcel');
+      const wb = await createStandardFormWorkbook(
+        staffSchedules,
+        staffList,
+        shiftSettings,
+        facilityName,
+        targetMonth,
+        standardWeeklyHours
+      );
+      await downloadExcel(wb, generateStandardFormFilename(targetMonth));
+    } catch {
+      // エクスポートエラーは静かに処理（ToastContextが使用できないため）
+      console.error('Excel export failed');
+    } finally {
+      setIsExporting(false);
+    }
+  }, [staffSchedules, staffList, shiftSettings, facilityName, targetMonth, standardWeeklyHours]);
+
+  // 役職別FTE合計テーブルの行
+  const roleEntries = (Object.entries(result.fteTotalByRole) as [string, number][]).sort((a, b) => a[0].localeCompare(b[0]));
+
+  // 違反をタイプ別にグループ化
+  const breakViolations = result.violations.filter((v) => v.type === 'break_time');
+  const intervalViolations = result.violations.filter((v) => v.type === 'rest_interval');
+
+  return (
+    <div className="space-y-6">
+      {/* コントロールバー */}
+      <div className="flex flex-wrap gap-4 items-center justify-between bg-white rounded-lg p-4 shadow-sm">
+        <div className="flex flex-wrap gap-4 items-center">
+          {/* 予定/実績トグル */}
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-gray-700">集計基準:</span>
+            <button
+              onClick={() => setUseActual(false)}
+              className={`px-3 py-1.5 text-sm rounded-l-md border ${
+                !useActual
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+              }`}
+            >
+              予定
+            </button>
+            <button
+              onClick={() => setUseActual(true)}
+              className={`px-3 py-1.5 text-sm rounded-r-md border-t border-r border-b -ml-px ${
+                useActual
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+              }`}
+            >
+              実績
+            </button>
+          </div>
+
+          {/* 週所定労働時間 */}
+          <div className="flex items-center gap-2">
+            <label htmlFor="weeklyHours" className="text-sm font-medium text-gray-700 whitespace-nowrap">
+              週所定労働時間:
+            </label>
+            <input
+              id="weeklyHours"
+              type="number"
+              min={1}
+              max={48}
+              value={standardWeeklyHours}
+              onChange={(e) => setStandardWeeklyHours(Math.max(1, Math.min(48, Number(e.target.value))))}
+              className="w-16 border border-gray-300 rounded px-2 py-1 text-sm text-center"
+            />
+            <span className="text-sm text-gray-500">h/週</span>
+          </div>
+        </div>
+
+        {/* Excel エクスポート */}
+        <button
+          onClick={handleExcelExport}
+          disabled={isExporting}
+          className="inline-flex items-center gap-2 px-4 py-2 bg-green-600 text-white text-sm font-medium rounded-lg hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {isExporting ? (
+            <svg className="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+          ) : (
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+            </svg>
+          )}
+          勤務形態一覧表（Excel）
+        </button>
+      </div>
+
+      {/* サマリーカード */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <SummaryCard
+          label="対象スタッフ数"
+          value={result.fteEntries.length}
+          colorClass="bg-blue-50 text-blue-900"
+        />
+        <SummaryCard
+          label="FTE合計"
+          value={`${Math.round(totalFte * 100) / 100} 人`}
+          colorClass="bg-indigo-50 text-indigo-900"
+        />
+        <SummaryCard
+          label="違反件数"
+          value={errorCount}
+          colorClass={errorCount > 0 ? 'bg-red-50 text-red-900' : 'bg-green-50 text-green-900'}
+        />
+        <SummaryCard
+          label="注意件数"
+          value={warningCount}
+          colorClass={warningCount > 0 ? 'bg-yellow-50 text-yellow-900' : 'bg-green-50 text-green-900'}
+        />
+      </div>
+
+      {/* 役職別FTE合計 */}
+      {roleEntries.length > 0 && (
+        <section className="bg-white rounded-lg shadow-sm overflow-hidden">
+          <h2 className="px-4 py-3 text-base font-semibold text-gray-900 border-b">
+            役職別 常勤換算合計
+          </h2>
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">職種</th>
+                  <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">FTE合計</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-100">
+                {roleEntries.map(([role, fte]) => (
+                  <tr key={role}>
+                    <td className="px-4 py-2 text-sm text-gray-900">{role}</td>
+                    <td className="px-4 py-2 text-sm text-right font-medium text-gray-900">
+                      {fte.toFixed(2)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {/* スタッフ別FTEテーブル */}
+      <section className="bg-white rounded-lg shadow-sm overflow-hidden">
+        <h2 className="px-4 py-3 text-base font-semibold text-gray-900 border-b">
+          スタッフ別 常勤換算（FTE）
+        </h2>
+        {result.fteEntries.length === 0 ? (
+          <p className="p-4 text-sm text-gray-500">データがありません</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">氏名</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase hidden sm:table-cell">職種</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase hidden md:table-cell">雇用形態</th>
+                  <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">月間勤務時間</th>
+                  <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase hidden sm:table-cell">週平均</th>
+                  <th className="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">常勤換算</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-100">
+                {result.fteEntries.map((entry: FullTimeEquivalentEntry) => (
+                  <tr key={entry.staffId} className="hover:bg-gray-50">
+                    <td className="px-4 py-2 text-sm text-gray-900">{entry.staffName}</td>
+                    <td className="px-4 py-2 text-sm text-gray-600 hidden sm:table-cell">{entry.role || '—'}</td>
+                    <td className="px-4 py-2 text-sm text-gray-600 hidden md:table-cell">
+                      {EMP_TYPE_LABELS[entry.employmentType] ?? entry.employmentType}
+                    </td>
+                    <td className="px-4 py-2 text-sm text-right text-gray-900">{entry.monthlyHours.toFixed(1)}h</td>
+                    <td className="px-4 py-2 text-sm text-right text-gray-600 hidden sm:table-cell">
+                      {entry.weeklyAverageHours.toFixed(1)}h
+                    </td>
+                    <td className="px-4 py-2 text-sm text-right font-semibold text-gray-900">
+                      {entry.fteValue.toFixed(2)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+        <p className="px-4 py-2 text-xs text-gray-400 border-t">
+          常勤換算 = 月間勤務時間 ÷ (週所定{standardWeeklyHours}h × 4.33週)
+        </p>
+      </section>
+
+      {/* 違反一覧 */}
+      <section className="bg-white rounded-lg shadow-sm overflow-hidden">
+        <h2 className="px-4 py-3 text-base font-semibold text-gray-900 border-b">
+          コンプライアンス違反 / 注意事項
+        </h2>
+
+        {result.violations.length === 0 ? (
+          <div className="p-6 text-center">
+            <div className="inline-flex items-center gap-2 text-green-700 bg-green-50 rounded-full px-4 py-2">
+              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <span className="text-sm font-medium">違反・注意事項は検出されませんでした</span>
+            </div>
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-100">
+            {/* 休憩時間違反 */}
+            {breakViolations.length > 0 && (
+              <ViolationGroup
+                title={`${TYPE_LABELS.break_time}（労働基準法第34条）`}
+                violations={breakViolations}
+              />
+            )}
+            {/* インターバル注意 */}
+            {intervalViolations.length > 0 && (
+              <ViolationGroup
+                title={`${TYPE_LABELS.rest_interval}（労働時間等設定改善法指針）`}
+                violations={intervalViolations}
+              />
+            )}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function ViolationGroup({
+  title,
+  violations,
+}: {
+  title: string;
+  violations: ComplianceViolationItem[];
+}) {
+  return (
+    <div className="p-4">
+      <h3 className="text-sm font-semibold text-gray-700 mb-3">{title}</h3>
+      <ul className="space-y-2">
+        {violations.map((v, i) => (
+          <li key={i} className="flex items-start gap-3 text-sm">
+            <span
+              className={`inline-block shrink-0 mt-0.5 px-2 py-0.5 text-xs font-medium rounded-full ${SEVERITY_STYLES[v.severity]}`}
+            >
+              {SEVERITY_LABELS[v.severity]}
+            </span>
+            <div className="min-w-0">
+              <span className="font-medium text-gray-800">{v.staffName}</span>
+              <span className="mx-1 text-gray-400">·</span>
+              <span className="text-gray-600">{v.description}</span>
+              <span className="ml-2 text-xs text-gray-400">({v.legalBasis})</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- 月次レポートページに「コンプライアンス」タブを追加（管理者/施設管理者向け）
- 常勤換算（FTE）テーブル・役職別FTE合計・違反一覧を表示する `ComplianceContent` コンポーネントを新規作成
- `reportService` に `getComplianceData` 関数を追加し、コンプライアンスチェックに必要な生データ（StaffSchedule/Staff/ShiftSettings）を一括取得

## 変更ファイル

| ファイル | 変更種別 | 説明 |
|---|---|---|
| `src/pages/reports/ComplianceContent.tsx` | 新規 | コンプライアンスタブUIコンポーネント |
| `src/pages/reports/ReportPage.tsx` | 修正 | コンプライアンスタブの追加 |
| `src/services/reportService.ts` | 修正 | `getComplianceData` 関数の追加 |

## 主な機能

- **予定/実績切り替えトグル**: コンプライアンスチェックを予定ベース/実績ベースで切り替え
- **週所定労働時間調整**: デフォルト40h、1〜48hで変更可能
- **FTEテーブル**: スタッフ別の月間勤務時間・週平均・常勤換算値を表示
- **役職別FTE合計**: 職種ごとのFTE合計を集計
- **違反一覧**: 労基法第34条（休憩時間）・インターバル（働き方改革）の違反・注意事項を表示
- **Excelダウンロード**: 標準様式第1号をExcelでダウンロード（#C実装のexportExcelを使用）

## Test plan

- [ ] TypeScript型チェック通過確認: `npx tsc --noEmit` → エラーなし ✅
- [ ] ユニットテスト 204件全通過確認 ✅
- [ ] 月次レポートページで「コンプライアンス」タブが管理者のみ表示されること
- [ ] 予定/実績トグルでFTE値が変化すること
- [ ] Excel ダウンロードが正常に動作すること
- [ ] 違反なし時に「違反・注意事項は検出されませんでした」が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)