### PR TITLE
docs: Phase 25 compliance-leave-management を Active Specifications テーブルに追加

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -36,6 +36,7 @@
 | hybrid-solver-poc | 57 | ✅ 完了 |
 | solver-production-deploy | 58 | ✅ 完了 |
 | dependency-updates-p0-p3 | 59 | ✅ 完了 |
+| compliance-leave-management | 25 | ✅ 完了 |
 
 ---
 


### PR DESCRIPTION
## Summary
- `docs/handoff/LATEST.md` の Active Specifications テーブルに `compliance-leave-management | 25 | ✅ 完了` の行が抜けていたので追加

## Test plan
- [ ] ドキュメントのみの変更のため、動作確認不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)