### PR TITLE
docs: Phase 39 tasks.md 完了状態に更新

### DIFF
--- a/.kiro/specs/leave-balance-management/tasks.md
+++ b/.kiro/specs/leave-balance-management/tasks.md
@@ -1,6 +1,7 @@
 # Phase 39: 休暇残高管理 - タスク一覧
 
 **作成日**: 2025-11-26
+**完了日**: 2026-02-19
 **仕様ID**: leave-balance-management
 **Phase**: 39
 
@@ -9,59 +10,59 @@
 ## タスク一覧
 
 ### 39.1 型定義追加 (30分)
-- [ ] `PublicHolidayBalance` interface追加
-- [ ] `PaidLeaveBalance` interface追加
-- [ ] `StaffLeaveBalance` interface追加
-- [ ] `LeaveAdjustment` interface追加
-- [ ] `FacilityLeaveSettings` interface追加
-- [ ] `LeaveBalanceError` type追加
+- [x] `PublicHolidayBalance` interface追加
+- [x] `PaidLeaveBalance` interface追加
+- [x] `StaffLeaveBalance` interface追加
+- [x] `LeaveAdjustment` interface追加
+- [x] `FacilityLeaveSettings` interface追加
+- [x] `LeaveBalanceError` type追加
 
 ### 39.2 定数追加 (15分)
-- [ ] `DEFAULT_LEAVE_SETTINGS` 追加
+- [x] `DEFAULT_LEAVE_SETTINGS` 追加
 
 ### 39.3 LeaveBalanceService実装 (2時間)
-- [ ] `getLeaveSettings()` 実装
-- [ ] `saveLeaveSettings()` 実装
-- [ ] `subscribeToLeaveSettings()` 実装
-- [ ] `getStaffLeaveBalances()` 実装
-- [ ] `getStaffLeaveBalance()` 実装
-- [ ] `adjustBalance()` 実装
-- [ ] `calculateBalance()` 実装
+- [x] `getLeaveSettings()` 実装
+- [x] `saveLeaveSettings()` 実装
+- [x] `subscribeToLeaveSettings()` 実装
+- [x] `getStaffLeaveBalances()` 実装
+- [x] `getStaffLeaveBalance()` 実装
+- [x] `adjustBalance()` 実装
+- [x] `calculateBalance()` 実装
 
 ### 39.4 LeaveSettingsPanel UI (1時間)
-- [ ] 設定パネルコンポーネント作成
-- [ ] 公休設定フォーム
-- [ ] 有給設定フォーム
-- [ ] 保存ハンドラー
+- [x] 設定パネルコンポーネント作成（App.tsx内に `handleSaveLeaveSettings` として統合）
+- [x] 公休設定フォーム
+- [x] 有給設定フォーム
+- [x] 保存ハンドラー
 
 ### 39.5 LeaveBalanceDashboard UI (2時間)
-- [ ] ダッシュボードコンポーネント作成
-- [ ] スタッフ一覧表示
-- [ ] 残高表示
-- [ ] 警告表示（残高少・マイナス）
-- [ ] フィルタ機能
-- [ ] ソート機能
+- [x] ダッシュボードコンポーネント作成（`src/components/LeaveBalanceDashboard.tsx` 491行）
+- [x] スタッフ一覧表示
+- [x] 残高表示
+- [x] 警告表示（残高少・マイナス）
+- [x] フィルタ機能
+- [x] ソート機能
 
 ### 39.6 LeaveBalanceDetailModal UI (1時間30分)
-- [ ] 詳細モーダルコンポーネント作成
-- [ ] 残高詳細表示
-- [ ] 調整履歴表示
-- [ ] 手動調整フォーム
+- [x] 詳細モーダルコンポーネント作成（LeaveBalanceDashboard.tsx内）
+- [x] 残高詳細表示
+- [x] 調整履歴表示
+- [x] 手動調整フォーム
 
 ### 39.7 App.tsx統合 (1時間)
-- [ ] `leaveSettings` state追加
-- [ ] `subscribeToLeaveSettings` 購読
-- [ ] アコーディオン追加
-- [ ] ダッシュボード組み込み
+- [x] `leaveSettings` state追加
+- [x] `subscribeToLeaveSettings` 購読
+- [x] アコーディオン追加（「休暇残高管理」セクション）
+- [x] ダッシュボード組み込み
 
 ### 39.8 Firestoreルール追加 (15分)
-- [ ] `leaveSettings` コレクションルール
-- [ ] `leaveBalances` コレクションルール
+- [x] `leaveSettings` コレクションルール
+- [x] `leaveBalances` コレクションルール
 
 ### 39.9 完了処理 (30分)
-- [ ] TypeScriptチェック
-- [ ] 完了記録作成
-- [ ] Git commit
+- [x] TypeScriptチェック
+- [x] 完了記録作成
+- [x] Git commit
 
 ---
 


### PR DESCRIPTION
## Summary

- Phase 39（leave-balance-management）の tasks.md が実装完了後もチェックボックスが `[ ]` のままだったため `[x]` に更新
- 実装自体は既にマージ済み（型定義・Service・Dashboard UI・App.tsx統合・Firestoreルール全て完了）
- CLAUDE.md の「Spec完了の定義」ルールに従い、ドキュメントと実装の整合性を確保

## 変更内容

- `.kiro/specs/leave-balance-management/tasks.md`: 39.1〜39.9 全チェックボックスを `[x]` に更新
- 39.4 は独立コンポーネントではなく App.tsx 内統合として実装済みであることを注記
- 完了日 2026-02-19 を追記

## Test plan

- [ ] TypeScript チェック通過済み（`npx tsc --noEmit` エラーなし）
- [ ] ドキュメントのみの変更のため動作影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Leave balance management feature implementation completed. All core functionality, user interface components, and backend services are now fully implemented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->