### PR TITLE
fix: staffingStandards Firestoreセキュリティルール追加（Phase 65漏れ）

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -258,6 +258,14 @@ service cloud.firestore {
         allow read, write: if isAuthenticated() && (isSuperAdmin() || hasRole(facilityId, 'admin'));
       }
 
+      // staffingStandards subcollection (Phase 65で実装)
+      // 人員配置基準設定
+      match /staffingStandards/{standardId} {
+        // viewer以上で読み取り、editor以上で書き込み
+        allow read: if isAuthenticated() && (isSuperAdmin() || hasRole(facilityId, 'viewer'));
+        allow write: if isAuthenticated() && hasRole(facilityId, 'editor');
+      }
+
       // notifications subcollection (Phase 63で実装)
       // シフト確定通知等
       match /notifications/{notificationId} {


### PR DESCRIPTION
## Summary

- Phase 65（PR #102）で `staffingStandardService.ts` 実装時に `firestore.rules` への `staffingStandards` サブコレクション定義が漏れていた
- 本番環境で人員配置基準ダッシュボードが全ユーザーで「Missing or insufficient permissions」エラーになっていた問題を修正
- 他のサブコレクション（`shiftSettings`/`leaveSettings`/`leaveBalances`等）と同じルールパターンを適用

## Test plan

- [ ] 本番環境（https://ai-care-shift-scheduler.web.app）で人員配置基準ダッシュボードを開く
- [ ] コンソールに `Missing or insufficient permissions` エラーが出ないことを確認
- [ ] viewer権限ユーザーで読み取りが成功することを確認
- [ ] editor権限ユーザーで書き込みが成功することを確認

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added staffing standards functionality with controlled access based on user permissions. Viewers can access staffing standards data; editors can make updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->