### PR TITLE
fix: Solver警告偽陽性修正 + roleMissing評価チェック追加

### DIFF
--- a/functions/src/evaluation/constraintLevelMapping.ts
+++ b/functions/src/evaluation/constraintLevelMapping.ts
@@ -23,6 +23,7 @@ export const CONSTRAINT_LEVEL_MAPPING: Record<ConstraintViolationType, Constrain
   // レベル2（運営必須）: 人員・資格基準
   staffShortage: 2, // 人員不足
   qualificationMissing: 2, // 資格要件未充足
+  roleMissing: 2, // ロール要件未充足（看護師等）
 
   // レベル3（努力目標）: 希望・連勤
   consecutiveWork: 3, // 連勤超過

--- a/functions/src/evaluation/evaluationLogic.ts
+++ b/functions/src/evaluation/evaluationLogic.ts
@@ -25,6 +25,7 @@ import {
   checkConsecutiveWorkViolation as checkConsecutiveWorkViolationFn,
   checkNightRestViolation as checkNightRestViolationFn,
   checkQualificationMissing as checkQualificationMissingFn,
+  checkRoleMissing as checkRoleMissingFn,
   checkLeaveRequestIgnored as checkLeaveRequestIgnoredFn,
   checkTimeSlotPreferenceViolation as checkTimeSlotPreferenceViolationFn,
 } from './constraintCheckers';
@@ -76,6 +77,13 @@ export class EvaluationService {
     violations.push(...this.checkNightRestViolation(input.schedule));
     violations.push(
       ...this.checkQualificationMissing(
+        input.schedule,
+        input.staffList,
+        input.requirements
+      )
+    );
+    violations.push(
+      ...this.checkRoleMissing(
         input.schedule,
         input.staffList,
         input.requirements
@@ -254,6 +262,19 @@ export class EvaluationService {
   ): ConstraintViolation[] {
     // 抽出した関数に委譲
     return checkQualificationMissingFn(schedule, staffList, requirements);
+  }
+
+  /**
+   * ロール要件未充足を検出（看護師・ケアマネ等）
+   * 注: デイサービス（夜勤なし）の場合、日曜日は営業外としてスキップ
+   */
+  checkRoleMissing(
+    schedule: StaffSchedule[],
+    staffList: Staff[],
+    requirements: ShiftRequirement
+  ): ConstraintViolation[] {
+    // 抽出した関数に委譲
+    return checkRoleMissingFn(schedule, staffList, requirements);
   }
 
   /**

--- a/functions/src/solver-client.ts
+++ b/functions/src/solver-client.ts
@@ -29,8 +29,16 @@ function expandRequirementsToDaily(requirements: ShiftRequirement): ShiftRequire
   const [year, month] = requirements.targetMonth.split('-').map(Number);
   const daysInMonth = new Date(year, month, 0).getDate();
 
+  // 夜勤施設かどうか判定（シフト名に「夜」が含まれる場合）
+  const isNightFacility = keys.some(k => k.includes('夜'));
+
   const expanded: Record<string, typeof requirements.requirements[string]> = {};
   for (let day = 1; day <= daysInMonth; day++) {
+    // デイサービス（非夜勤施設）の場合、日曜日をスキップ（非稼働日）
+    if (!isNightFacility) {
+      const date = new Date(year, month - 1, day);
+      if (date.getDay() === 0) continue;
+    }
     const dateStr = `${requirements.targetMonth}-${String(day).padStart(2, '0')}`;
     for (const [shiftName, dailyReq] of Object.entries(requirements.requirements)) {
       expanded[`${dateStr}_${shiftName}`] = dailyReq;

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -123,6 +123,7 @@ export type ConstraintViolationType =
   | 'consecutiveWork'      // 連勤超過
   | 'nightRestViolation'   // 夜勤後休息不足
   | 'qualificationMissing' // 資格要件未充足
+  | 'roleMissing'          // ロール要件未充足（看護師等）
   | 'leaveRequestIgnored'; // 休暇希望未反映
 
 /**


### PR DESCRIPTION
## 概要

Solver事前検証警告が20件発生していた原因を調査・修正し、ロール要件未充足（看護師等）の評価チェックを追加。

## 修正内容

### Bug A: Solver警告偽陽性 (Closes #108)

**原因**: `expandRequirementsToDaily()` がデイサービス（非夜勤施設）でも日曜日の要件を展開していた。Solverは日曜日を非稼働日として扱うため、「配置可能スタッフ0名」の状態を検出して警告していた。

**修正**: シフト名に「夜」が含まれない施設（デイサービス）は、日曜日をスキップして要件を展開しないよう変更。

### Bug B: roleMissing 評価チェック追加 (Closes #109)

**原因**: `checkQualificationMissing` は `requiredQualifications` のみチェックしており、`requiredRoles`（看護師・ケアマネ等）をチェックしていなかった。ロール要件違反がスコアに未反映。

**修正**:
- `ConstraintViolationType` に `'roleMissing'` を追加
- `checkRoleMissing()` 関数を `constraintCheckers.ts` に実装
- `CONSTRAINT_LEVEL_MAPPING` に `roleMissing: 2`（運営必須）を追加
- `EvaluationService` に委譲メソッドを追加し `evaluateSchedule` から呼び出し

## テスト

- `checkRoleMissing` の4ユニットテストを追加
- 全234テスト通過（TypeScript型チェック通過）

## 影響範囲

| ファイル | 変更内容 |
|---------|---------|
| `functions/src/solver-client.ts` | 日曜日スキップロジック追加 |
| `functions/src/types.ts` | `roleMissing` 型追加 |
| `functions/src/evaluation/constraintCheckers.ts` | `checkRoleMissing()` 関数追加 |
| `functions/src/evaluation/constraintLevelMapping.ts` | `roleMissing: 2` 追加 |
| `functions/src/evaluation/evaluationLogic.ts` | import・委譲メソッド・呼び出し追加 |
| `functions/__tests__/unit/constraintCheckers.test.ts` | テスト4件追加 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added role requirement validation to detect insufficient staffing for specific roles per shift type.
  * Day service facilities now skip Sunday coverage requirements, optimizing scheduling for day-only operations.

* **Bug Fixes**
  * Improved constraint evaluation to properly account for night vs. day facility operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->